### PR TITLE
Minor changes when dealing with optional variables

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -47,12 +47,12 @@ public class ClientRequest: BlueSocketWriter {
     ///
     /// Username if using Basic Auth 
     ///
-    private var userName: String? = nil
+    private var userName: String?
     
     /// 
     /// Password if using Basic Auth 
     ///
-    private var password: String? = nil
+    private var password: String?
 
     ///
     /// Maximum number of redirects before failure
@@ -141,8 +141,8 @@ public class ClientRequest: BlueSocketWriter {
         }
 
         // Adding support for Basic HTTP authentication
-        let user = self.userName != nil ? self.userName! : ""
-        let pwd = self.password != nil ? self.password! : ""
+        let user = self.userName ?? ""
+        let pwd = self.password ?? ""
         var authenticationClause = ""
         if (!user.isEmpty && !pwd.isEmpty) {
             
@@ -381,7 +381,7 @@ private class CurlInvoker {
     ///
     /// Delegate that can have a read or write callback
     ///
-    private weak var delegate: CurlInvokerDelegate? = nil
+    private weak var delegate: CurlInvokerDelegate?
     
     ///
     /// Maximum number of redirects 


### PR DESCRIPTION
Swift's optional chaining is usually preferable to ternary operators when checking for `nil`, so it was adopted for the `user` and `pwd` variables.  Unnecessary `nil` assignments were also removed from optional variable declarations.