### PR TITLE
Fixes inout error

### DIFF
--- a/Sources/KituraNet/BufferList.swift
+++ b/Sources/KituraNet/BufferList.swift
@@ -85,7 +85,7 @@ public class BufferList {
     ///
     /// - Returns:
     ///
-    public func fillArray(inout buffer: [UInt8]) -> Int {
+    public func fillArray(buffer: inout [UInt8]) -> Int {
         
         let result = min(buffer.count, lclData!.length-byteIndex)
         memcpy(UnsafeMutablePointer<UInt8>(buffer), lclData!.bytes+byteIndex, result)


### PR DESCRIPTION
This error appears when installing kitura via docker

```
/root/Kitura/Packages/Kitura-net-0.3.5/Sources/KituraNet/BufferList.swift:88:27: warning: 'inout' before a parameter name is deprecated, place it before the parameter type instead
    public func fillArray(inout buffer: [UInt8]) -> Int {
```