### PR TITLE
Improves ClientRequest initialiser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-.build
-Packages
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -122,7 +122,7 @@ public class ClientRequest: SocketWriter {
                 case .method(let method):
                     self.method = method
                 case .schema(var schema):
-                    if !schema.contains("://") {
+                    if !schema.contains("://") && !schema.isEmpty {
                       schema += "://"
                     }
                     theSchema = schema

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -113,21 +113,27 @@ public class ClientRequest: SocketWriter {
 
         var theSchema = "http://"
         var hostName = "localhost"
-        var path = "/"
-        var port: Int16? = nil
+        var path = ""
+        var port = ""
 
         for option in options  {
             switch(option) {
 
                 case .method(let method):
                     self.method = method
-                case .schema(let schema):
+                case .schema(var schema):
+                    if !schema.contains("://") {
+                      schema += "://"
+                    }
                     theSchema = schema
                 case .hostname(let host):
                     hostName = host
                 case .port(let thePort):
-                    port = thePort
-                case .path(let thePath):
+                    port = ":\(thePort)"
+                case .path(var thePath):
+                    if thePath.characters.first != "/" {
+                      thePath = "/" + thePath
+                    }
                     path = thePath
                 case .headers(let headers):
                     for (key, value) in headers {
@@ -152,12 +158,7 @@ public class ClientRequest: SocketWriter {
           authenticationClause = "\(user):\(pwd)@"
         }
 
-        var portClause = ""
-        if  let port = port  {
-            portClause = ":\(String(port))"
-        }
-
-        url = "\(theSchema)\(authenticationClause)\(hostName)\(portClause)\(path)"
+        url = "\(theSchema)\(authenticationClause)\(hostName)\(port)\(path)"
 
     }
 

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -37,27 +37,27 @@ public class ClientRequest: SocketWriter {
     ///
     /// URL used for the request
     ///
-    private var url: String
+    public private(set) var url: String
     
     /// 
     /// HTTP method (GET, POST, PUT, DELETE) for the request
     ///
-    private var method: String = "get"
+    public private(set) var method: String = "get"
     
     ///
     /// Username if using Basic Auth 
     ///
-    private var userName: String?
+    public private(set) var userName: String?
     
     /// 
     /// Password if using Basic Auth 
     ///
-    private var password: String?
+    public private(set) var password: String?
 
     ///
     /// Maximum number of redirects before failure
     ///
-    private var maxRedirects = 10
+    public private(set) var maxRedirects = 10
     
     /// 
     /// ???

--- a/Tests/KituraNet/ClientE2ETests.swift
+++ b/Tests/KituraNet/ClientE2ETests.swift
@@ -20,9 +20,9 @@ import XCTest
 
 @testable import KituraNet
 
-class ClientTests: XCTestCase {
+class ClientE2ETests: XCTestCase {
 
-    static var allTests : [(String, ClientTests -> () throws -> Void)] {
+    static var allTests : [(String, ClientE2ETests -> () throws -> Void)] {
         return [
             ("testSimpleHTTPClient", testSimpleHTTPClient)
         ]

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -84,3 +84,18 @@ class ClientRequestTests: XCTestCase {
   }
   
 }
+
+extension ClientRequestTests {
+  static var allTests : [(String, ClientRequestTests -> () throws -> Void)] {
+    return [
+             ("testClientRequestWhenInitializedWithValidURL", testClientRequestWhenInitializedWithValidURL),
+             ("testClientRequestWhenInitializedWithSimpleSchema",
+              testClientRequestWhenInitializedWithSimpleSchema),
+             ("testClientRequestDefaultSchemaIsHTTP", testClientRequestDefaultSchemaIsHTTP),
+             ("testClientRequestDefaultMethodIsGET", testClientRequestDefaultMethodIsGET),
+             ("testClientRequestAppendsPathCorrectly", testClientRequestAppendsPathCorrectly),
+             ("testClientRequestAppendsMisformattedPathCorrectly", testClientRequestAppendsMisformattedPathCorrectly),
+             ("testClientRequestAppendsPort", testClientRequestAppendsPort)
+    ]
+  }
+}

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -1,0 +1,86 @@
+//
+//  ClientRequestTests.swift
+//  Kitura-net
+//
+//  Created by Michał Kalinowski on 26/05/16.
+//
+//
+
+import Foundation
+import XCTest
+
+@testable import KituraNet
+
+class ClientRequestTests: XCTestCase {
+  let testCallback: ClientRequestCallback = {_ in }
+  
+  // 1 test URL that is build when initializing with ClientRequestOptions
+  func testClientRequestWhenInitializedWithValidURL() {
+    let options: [ClientRequestOptions] = [ .method("GET"),
+                                            .schema("https://"),
+                                            .hostname("66o.tech")
+                                            ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.url, "https://66o.tech")
+  }
+  
+  func testClientRequestWhenInitializedWithSimpleSchema() {
+    let options: [ClientRequestOptions] = [ .method("GET"),
+                                            .schema("https"),
+                                            .hostname("66o.tech")
+    ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.url, "https://66o.tech")
+  }
+  
+  func testClientRequestDefaultSchemaIsHTTP() {
+    let options: [ClientRequestOptions] = [ .method("GET"),
+                                            .hostname("66o.tech")
+    ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.url, "http://66o.tech")
+  }
+  
+  func testClientRequestDefaultMethodIsGET() {
+    let options: [ClientRequestOptions] = [ .schema("https"),
+                                            .hostname("66o.tech")
+    ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.method, "get")
+  }
+  
+  func testClientRequestAppendsPathCorrectly() {
+    let options: [ClientRequestOptions] = [ .schema("https"),
+                                            .hostname("66o.tech"),
+                                            .path("path/to/resource")
+    ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.url, "https://66o.tech/path/to/resource")
+  }
+  
+  func testClientRequestAppendsMisformattedPathCorrectly() {
+    let options: [ClientRequestOptions] = [ .schema("https"),
+                                            .hostname("66o.tech"),
+                                            .path("/path/to/resource")
+    ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.url, "https://66o.tech/path/to/resource")
+  }
+  
+  func testClientRequestAppendsPort() {
+    let options: [ClientRequestOptions] = [ .schema("https"),
+                                            .hostname("66o.tech"),
+                                            .port(8080)
+    ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.url, "https://66o.tech:8080")
+  }
+  
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -19,6 +19,7 @@ import XCTest
 @testable import KituraNetTestSuite
 
 XCTMain([
-	testCase(ClientTests.allTests),
+	testCase(ClientE2ETests.allTests),
+  testCase(ClientRequestTests.allTests),
 	testCase(ParserTests.allTests)
 ])


### PR DESCRIPTION
Fixes a couple of bugs of ClientRequest initialiser (with ClientRequestOptions)

## Description
Adds very basic input sanitisation for `init(options: [ClientRequestOptions], callback: ...)` , extends test coverage and updates `.gitignore` to keep the repo clean in case one develops in Xcode.

## Motivation and Context
Current implementation doesn't sanitise options passed:
* if schema is passed without `://` request's url is invalid (reported here: #29) 
* if `/` is passed as a first character of the path backslash is doubled
* `/`is appended to url regardless if any path was passed

## How Has This Been Tested?
I've written tests to test changed behaviour of the initialiser in `ClientRequestTests.swift`
- [x] tests run on OSX
- [x] tests run on Ubuntu 15.10 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
