### PR TITLE
Avoid bottleneck on lock in __CFGetConverter

### DIFF
--- a/Sources/KituraNet/ServerResponse.swift
+++ b/Sources/KituraNet/ServerResponse.swift
@@ -168,30 +168,32 @@ public class ServerResponse : SocketWriter {
             return
         }
 
-        try writeToSocketThroughBuffer(text: "HTTP/1.1 ")
-        try writeToSocketThroughBuffer(text: String(status))
-        try writeToSocketThroughBuffer(text: " ")
+        var headerData = ""
+        headerData.append("HTTP/1.1 ")
+        headerData.append(String(status))
+        headerData.append(" ")
         var statusText = HTTP.statusCodes[status]
 
         if  statusText == nil {
             statusText = ""
         }
 
-        try writeToSocketThroughBuffer(text: statusText!)
-        try writeToSocketThroughBuffer(text: "\r\n")
+        headerData.append(statusText!)
+        headerData.append("\r\n")
 
         for (key, valueSet) in headers.headers {
             for value in valueSet {
-                try writeToSocketThroughBuffer(text: key)
-                try writeToSocketThroughBuffer(text: ": ")
-                try writeToSocketThroughBuffer(text: value)
-                try writeToSocketThroughBuffer(text: "\r\n")
+                headerData.append(key)
+                headerData.append(": ")
+                headerData.append(value)
+                headerData.append("\r\n")
             }
         }
         // We currently don't support keep alive
-        try writeToSocketThroughBuffer(text: "Connection: Close\r\n")
+        headerData.append("Connection: Close\r\n")
 
-        try writeToSocketThroughBuffer(text: "\r\n")
+        headerData.append("\r\n")
+        try writeToSocketThroughBuffer(text: headerData)
         startFlushed = true
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Avoid bottleneck on lock in __CFGetConverter by performing fewer, longer character conversion operations.

## Description
This change replaces a series of small String to UTF8 conversion operations with a series of String appends followed by a single UTF8 conversion, when writing the HTTP response header.

## Motivation and Context
This works around the performance problem described here: https://github.com/IBM-Swift/SwiftRuntime/issues/169
In short, the NSString.data(using: encoding) function gets a converter from __CFGetConverter, and this function includes a spinlock.  Profiling data that I collected with a simple 'Hello World' Kitura application showed up to 20% of time was being spent in this function due to lock contention, which seems unreasonable.
The contention seems to be particularly bad when many small conversion operations are being performed. By reducing the number of individual conversions we perform, we can avoid contention.  Whether the design of __CFGetConverter itself could be improved will be investigated separately.

## How Has This Been Tested?
I rebuilt my sample Kitura application with this change applied to the Kitura-net component.  I observed that it functioned normally when I requested either the default welcome page or my 'hello world' URL.  I did not run any other Kitura tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.