### PR TITLE
Add PostFields Support to ClientRequest

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -318,7 +318,7 @@ public class ClientRequest: SocketWriter {
         if  count != 0  {
             curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, count)
         }
-        setupPostFileds()
+        setupPostFields()
         setupHeaders()
         let emptyCstring = StringUtils.toNullTerminatedUtf8String("")!
         curlHelperSetOptString(handle!, CURLOPT_COOKIEFILE, UnsafeMutablePointer<Int8>(emptyCstring.bytes))
@@ -349,13 +349,13 @@ public class ClientRequest: SocketWriter {
 
     }
 
-    private func setupPostFileds() {
+    private func setupPostFields() {
         guard let postFields = postFields where method.uppercased() == "POST" else {
             return
         }
-        let postFiledsString = StringUtils.toNullTerminatedUtf8String(postFields)!
-        curlHelperSetOptString(handle!, CURLOPT_POSTFIELDS, UnsafeMutablePointer<Int8>(postFiledsString.bytes))
-        curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, postFiledsString.length)
+        let postFieldsString = StringUtils.toNullTerminatedUtf8String(postFields)!
+        curlHelperSetOptString(handle!, CURLOPT_POSTFIELDS, UnsafeMutablePointer<Int8>(postFieldsString.bytes))
+        curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, postFieldsString.length)
     }
 
     ///

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -62,7 +62,7 @@ public class ClientRequest: SocketWriter {
     ///
     /// Send a POST with this data
     ///
-    public private(set) var postFileds: String?
+    public private(set) var postFields: String?
     
     /// 
     /// ???
@@ -95,7 +95,7 @@ public class ClientRequest: SocketWriter {
     public enum Options {
         
         case method(String), schema(String), hostname(String), port(Int16), path(String),
-        headers([String: String]), username(String), password(String), maxRedirects(Int), postFileds(String), disableSSLVerification
+        headers([String: String]), username(String), password(String), maxRedirects(Int), postFields(String), disableSSLVerification
         
     }
     
@@ -165,8 +165,8 @@ public class ClientRequest: SocketWriter {
                     self.password = password
                 case .maxRedirects(let maxRedirects):
                     self.maxRedirects = maxRedirects
-                case .postFileds(let postFileds):
-                    self.postFileds = postFileds
+                case .postFields(let postFields):
+                    self.postFields = postFields 
                 case .disableSSLVerification:
                     self.disableSSLVerification = true
             }
@@ -350,10 +350,10 @@ public class ClientRequest: SocketWriter {
     }
 
     private func setupPostFileds() {
-        guard let postFileds = postFileds where method.uppercased() == "POST" else {
+        guard let postFields = postFields where method.uppercased() == "POST" else {
             return
         }
-        let postFiledsString = StringUtils.toNullTerminatedUtf8String(postFileds)!
+        let postFiledsString = StringUtils.toNullTerminatedUtf8String(postFields)!
         curlHelperSetOptString(handle!, CURLOPT_POSTFIELDS, UnsafeMutablePointer<Int8>(postFiledsString.bytes))
         curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, postFiledsString.length)
     }

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -1,18 +1,10 @@
-/**
- * Copyright IBM Corporation 2016
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
+//
+//  ClientRequestTests.swift
+//  Kitura-net
+//
+//  Created by Michał Kalinowski on 26/05/16.
+//
+//
 
 import Foundation
 import XCTest

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -1,10 +1,18 @@
-//
-//  ClientRequestTests.swift
-//  Kitura-net
-//
-//  Created by Michał Kalinowski on 26/05/16.
-//
-//
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
 
 import Foundation
 import XCTest

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -86,11 +86,11 @@ class ClientRequestTests: XCTestCase {
   func testClientRequestAppendsPostFields() {
     let options: [ClientRequest.Options] = [ .schema("https"),
                                             .hostname("66o.tech"),
-                                            .postFileds("post_body"),
+                                            .postFields("post_body"),
     ]
     let testRequest = ClientRequest(options: options, callback: testCallback)
     
-    XCTAssertEqual(testRequest.postFileds, "post_body")
+    XCTAssertEqual(testRequest.postFields, "post_body")
   }
 
 }

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -82,7 +82,17 @@ class ClientRequestTests: XCTestCase {
     
     XCTAssertEqual(testRequest.url, "https://66o.tech:8080")
   }
-  
+
+  func testClientRequestAppendsPostFields() {
+    let options: [ClientRequest.Options] = [ .schema("https"),
+                                            .hostname("66o.tech"),
+                                            .postFileds("post_body"),
+    ]
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    
+    XCTAssertEqual(testRequest.postFileds, "post_body")
+  }
+
 }
 
 extension ClientRequestTests {
@@ -95,7 +105,8 @@ extension ClientRequestTests {
              ("testClientRequestDefaultMethodIsGET", testClientRequestDefaultMethodIsGET),
              ("testClientRequestAppendsPathCorrectly", testClientRequestAppendsPathCorrectly),
              ("testClientRequestAppendsMisformattedPathCorrectly", testClientRequestAppendsMisformattedPathCorrectly),
-             ("testClientRequestAppendsPort", testClientRequestAppendsPort)
+             ("testClientRequestAppendsPort", testClientRequestAppendsPort),
+             ("testClientRequestAppendsPostFields", testClientRequestAppendsPostFields),
     ]
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR Add Postfields Suport to ClientRequest.
## Description
<!--- Describe your changes in detail -->
Added postFileds to option enum and setup method for this. It's enabled send post with a data.
## Motivation and Context
When sending external API request on Kitura, we generally use the ClientRequest.But ClientRequest isn't support a sending post <b>with a data</b>, so we can't use major external API by Kitura, Kitura-net.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I confirmed it can post a data by requested to my own server and view logs. And  I added a test code of postFileds to ClientRequestTests.swift.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
I have submitted a CLA form, just now 😸 
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

