### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = Kitura-Build
 	url = https://github.com/IBM-Swift/Kitura-Build.git
 	ignore = all
-	branch = master
+	branch = develop


### PR DESCRIPTION
## Description
there is no `master` branch in the `Kitura-Build` project so this project will fail to pull the submodule

## Motivation and Context
the Kitura-net project is not able to pull the submodule failing many projects depending on it