### PR TITLE
Fix for Kitura issue 508

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -308,9 +308,7 @@ public class ClientRequest: SocketWriter {
         }
         setMethod()
         let count = writeBuffers.count
-        if  count != 0  {
-            curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, count)
-        }
+        curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, count)
         setupHeaders()
         curlHelperSetOptString(handle!, CURLOPT_COOKIEFILE, "")
 

--- a/Tests/KituraNet/ClientE2ETests.swift
+++ b/Tests/KituraNet/ClientE2ETests.swift
@@ -19,14 +19,22 @@ import Foundation
 import XCTest
 
 @testable import KituraNet
+import Socket
 
 class ClientE2ETests: XCTestCase {
 
     static var allTests : [(String, (ClientE2ETests) -> () throws -> Void)] {
         return [
-            ("testSimpleHTTPClient", testSimpleHTTPClient)
+            ("testSimpleHTTPClient", testSimpleHTTPClient),
+            ("testPostRequests", testPostRequests)
         ]
     }
+    
+    override func tearDown() {
+        doTearDown()
+    }
+    
+    let delegate = ServerDelegate()
     
     func testSimpleHTTPClient() {
         _ = HTTP.get("http://www.ibm.com") {response in
@@ -35,6 +43,69 @@ class ClientE2ETests: XCTestCase {
             let contentType = response!.headers["Content-Type"]
             XCTAssertNotNil(contentType, "No ContentType header in response")
             XCTAssertEqual(contentType!, ["text/html"], "Content-Type header wasn't `text/html`")
+        }
+    }
+    
+    func testPostRequests() {
+        performServerTest(delegate, asyncTasks: { expectation in
+            self.performRequest("post", path: "/posttest", callback: {response in
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                do {
+                    let data = NSMutableData()
+                    let count = try response!.readAllData(into: data)
+                    XCTAssertEqual(count, 12, "Result should have been 12 bytes, was \(count) bytes")
+                    if  let postValue = String(data: data, encoding: NSUTF8StringEncoding) {
+                        XCTAssertEqual(postValue, "Read 0 bytes")
+                    }
+                    else {
+                        XCTFail("postValue's value wasn't an UTF8 string")
+                    }
+                }
+                catch {
+                    XCTFail("Failed reading the body of the response")
+                }
+                expectation.fulfill()
+            })
+        },
+        { expectation in
+            self.performRequest("post", path: "/posttest", callback: {response in
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                do {
+                    let data = NSMutableData()
+                    let count = try response!.readAllData(into: data)
+                    XCTAssertEqual(count, 13, "Result should have been 13 bytes, was \(count) bytes")
+                    if  let postValue = String(data: data, encoding: NSUTF8StringEncoding) {
+                        XCTAssertEqual(postValue, "Read 16 bytes")
+                    }
+                    else {
+                        XCTFail("postValue's value wasn't an UTF8 string")
+                    }
+                }
+                catch {
+                    XCTFail("Failed reading the body of the response")
+                }
+                expectation.fulfill()
+            }) {request in
+                request.write(from: "A few characters")
+            }
+        })
+    }
+    
+    class ServerDelegate : HTTPServerDelegate {
+    
+        func handle(request: ServerRequest, response: ServerResponse) {
+            let body = NSMutableData()
+            do {
+                let length = try request.readAllData(into: body)
+                let result = "Read \(length) bytes"
+                response.headers["Content-Type"] = ["text/plain"]
+                response.headers["Content-Length"] = ["\(result.characters.count)"]
+            
+                try response.end(text: result)
+            }
+            catch {
+                print("Error reading body or writing response")
+            }
         }
     }
 }

--- a/Tests/KituraNet/KituraNetTest.swift
+++ b/Tests/KituraNet/KituraNetTest.swift
@@ -1,9 +1,83 @@
-//
-//  KituraNetTest.swift
-//  Kitura-net
-//
-//  Created by Samuel Kallner on 04/07/2016.
-//
-//
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+
+@testable import KituraNet
+@testable import KituraSys
 
 import Foundation
+
+protocol KituraNetTest {
+    func expectation(_ index: Int) -> XCTestExpectation
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?)
+}
+
+extension KituraNetTest {
+    
+    func doTearDown() {
+        //       sleep(10)
+    }
+    
+    func performServerTest(_ delegate: HTTPServerDelegate, asyncTasks: (expectation: XCTestExpectation) -> Void...) {
+        let server = setupServer(port: 8090, delegate: delegate)
+        let requestQueue = Queue(type: .serial)
+        
+        for (index, asyncTask) in asyncTasks.enumerated() {
+            let expectation = self.expectation(index)
+            requestQueue.enqueueAsynchronously {
+                asyncTask(expectation: expectation)
+            }
+        }
+        
+        waitExpectation(timeout: 10) { error in
+            // blocks test until request completes
+            server.stop()
+            XCTAssertNil(error);
+        }
+    }
+    
+    func performRequest(_ method: String, path: String, callback: ClientRequest.Callback, headers: [String: String]? = nil, requestModifier: ((ClientRequest) -> Void)? = nil) {
+        var allHeaders = [String: String]()
+        if  let headers = headers  {
+            for  (headerName, headerValue) in headers  {
+                allHeaders[headerName] = headerValue
+            }
+        }
+        allHeaders["Content-Type"] = "text/plain"
+        let req = HTTP.request([.method(method), .hostname("localhost"), .port(8090), .path(path), .headers(allHeaders)], callback: callback)
+        if let requestModifier = requestModifier {
+            requestModifier(req)
+        }
+        req.end()
+    }
+    
+    private func setupServer(port: Int, delegate: HTTPServerDelegate) -> HTTPServer {
+        return HTTPServer.listen(port: port, delegate: delegate,
+                                 notOnMainQueue:true)
+    }
+}
+
+extension XCTestCase: KituraNetTest {
+    func expectation(_ index: Int) -> XCTestExpectation {
+        let expectationDescription = "\(self.dynamicType)-\(index)"
+        return self.expectation(withDescription: expectationDescription)
+    }
+    
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        self.waitForExpectations(withTimeout: t, handler: handler)
+    }
+}

--- a/Tests/KituraNet/KituraNetTest.swift
+++ b/Tests/KituraNet/KituraNetTest.swift
@@ -1,0 +1,9 @@
+//
+//  KituraNetTest.swift
+//  Kitura-net
+//
+//  Created by Samuel Kallner on 04/07/2016.
+//
+//
+
+import Foundation


### PR DESCRIPTION
This is the fix for IBM-Swift/Kitura#508

## Description
Always cause libCurl to send a Content-Length header

## Motivation and Context
POST's with a zero length header were hanging

## How Has This Been Tested?
I added a pair of tests to KituraNet that test POST requests made to a KituraNet based server.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
