### PR TITLE
Refactor Kitura-Net Classes to Reference HTTP (Prep for Multi Protocol)

### DIFF
--- a/Sources/KituraNet/ClientResponse.swift
+++ b/Sources/KituraNet/ClientResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 
 // MARK: ClientResponse
 
-public class ClientResponse: IncomingMessage {
+public class ClientResponse: HTTPIncomingMessage {
     
     ///
     /// Initializes a ClientResponse instance

--- a/Sources/KituraNet/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTPIncomingMessage.swift
@@ -22,7 +22,7 @@ import Foundation
 
 // MARK: IncomingMessage
 
-public class IncomingMessage : HTTPParserDelegate, SocketReader {
+public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
 
     ///
     /// Default buffer size used for creating a BufferList
@@ -101,12 +101,12 @@ public class IncomingMessage : HTTPParserDelegate, SocketReader {
     ///
     /// TODO: ???
     ///
-    private var ioBuffer = NSMutableData(capacity: IncomingMessage.bufferSize)
+    private var ioBuffer = NSMutableData(capacity: HTTPIncomingMessage.bufferSize)
     
     ///
     /// TODO: ???
     ///
-    private var buffer = NSMutableData(capacity: IncomingMessage.bufferSize)
+    private var buffer = NSMutableData(capacity: HTTPIncomingMessage.bufferSize)
 
     ///
     /// Indicates if the parser should save the message body and call onBody()

--- a/Sources/KituraNet/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTPIncomingMessage.swift
@@ -130,8 +130,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
     ///
     /// HTTP parser error types
     ///
-    public enum HTTPParserErrorType {
-        
+    enum HTTPParserErrorType {
         case success
         case parsedLessThanRead
         case unexpectedEOF

--- a/Sources/KituraNet/HTTPServer.swift
+++ b/Sources/KituraNet/HTTPServer.swift
@@ -164,8 +164,8 @@ public class HTTPServer {
         
         HTTPServer.clientHandlerQueue.enqueueAsynchronously() {
 
-            let request = ServerRequest(socket: clientSocket)
-            let response = ServerResponse(socket: clientSocket, request: request)
+            let request = HTTPServerRequest(socket: clientSocket)
+            let response = HTTPServerResponse(socket: clientSocket, request: request)
             request.parse() { status in
                 switch status {
                 case .success:

--- a/Sources/KituraNet/HTTPServer.swift
+++ b/Sources/KituraNet/HTTPServer.swift
@@ -35,7 +35,7 @@ public class HTTPServer {
     ///
     /// HTTPServerDelegate
     ///
-    public weak var delegate: HTTPServerDelegate?
+    public weak var delegate: ServerDelegate?
     
     /// 
     /// Port number for listening for new connections
@@ -106,7 +106,7 @@ public class HTTPServer {
     ///
     /// - Returns: a new HTTPServer instance
     ///
-    public static func listen(port: Int, delegate: HTTPServerDelegate, notOnMainQueue: Bool=false) -> HTTPServer {
+    public static func listen(port: Int, delegate: ServerDelegate, notOnMainQueue: Bool=false) -> HTTPServer {
         
         let server = HTTP.createServer()
         server.delegate = delegate
@@ -187,13 +187,4 @@ public class HTTPServer {
 
         }
     }
-}
-
-///
-/// Delegate protocol for an HTTPServer
-///
-public protocol HTTPServerDelegate: class {
-
-    func handle(request: ServerRequest, response: ServerResponse)
-    
 }

--- a/Sources/KituraNet/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTPServerRequest.swift
@@ -1,0 +1,63 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+import Socket
+
+// MARK: HTTPServerRequest
+
+public class HTTPServerRequest: HTTPIncomingMessage, ServerRequest {
+
+    ///
+    /// Socket for the request
+    ///
+    private let socket: Socket
+
+    ///
+    /// server IP address pulled from socket
+    ///
+    public var remoteAddress: String {
+        return socket.remoteHostname
+    }
+    
+    ///
+    /// Initializes a HTTPServerRequest
+    ///
+    /// - Parameter socket: the socket 
+    ///
+    init (socket: Socket) {
+        
+        self.socket = socket
+        super.init(isRequest: true)
+        
+        setup(self)
+    }
+}
+
+/// IncomingMessageHelper protocol extension
+extension HTTPServerRequest: IncomingMessageHelper {
+    
+    ///
+    /// TODO: ???
+    ///
+    func readHelper(into data: NSMutableData) throws -> Int {
+
+        let length = try socket.read(into: data)
+        return length > 0 ? length : (socket.isConnected ? 0 : -1)
+    }
+    
+}

--- a/Sources/KituraNet/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTPServerResponse.swift
@@ -1,0 +1,220 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import KituraSys
+import Socket
+
+import Foundation
+
+// MARK: HTTPServerResponse
+
+public class HTTPServerResponse : SocketWriter, ServerResponse {
+
+    ///
+    /// Socket for the HTTPServerResponse
+    ///
+    private var socket: Socket?
+
+    ///
+    /// Size of buffer
+    ///
+    private static let bufferSize = 2000
+
+    ///
+    /// Buffer for HTTP response line, headers, and short bodies
+    ///
+    private var buffer: NSMutableData
+
+    ///
+    /// Whether or not the HTTP response line and headers have been flushed.
+    ///
+    private var startFlushed = false
+
+    ///
+    /// TODO: ???
+    ///
+    public var headers = HeadersContainer()
+    
+    ///
+    /// Status code
+    ///
+    private var status = HTTPStatusCode.OK.rawValue
+    
+    ///
+    /// Corresponding server request
+    ///
+    private weak var serverRequest : HTTPServerRequest?
+
+    ///
+    /// Status code
+    ///
+    public var statusCode: HTTPStatusCode? {
+        get {
+            return HTTPStatusCode(rawValue: status)
+        }
+        set (newValue) {
+            if let newValue = newValue where !startFlushed {
+                status = newValue.rawValue
+            }
+        }
+    }
+
+    ///
+    /// Initializes a HTTPServerResponse instance
+    ///
+    init(socket: Socket, request: HTTPServerRequest) {
+
+        self.socket = socket
+        serverRequest = request
+        buffer = NSMutableData(capacity: HTTPServerResponse.bufferSize)!
+        headers["Date"] = [SPIUtils.httpDate()]
+    }
+
+    ///
+    /// Write a string as a response
+    ///
+    /// - Parameter string: String data to be written.
+    ///
+    /// - Throws: ???
+    ///
+    public func write(from string: String) throws {
+
+        if  socket != nil  {
+            try flushStart()
+            try writeToSocketThroughBuffer(text: string)
+        }
+
+    }
+
+    ///
+    /// Write data as a response
+    ///
+    /// - Parameter data: NSMutableData object to contain read data.
+    ///
+    /// - Returns: Integer representing the number of bytes read.
+    ///
+    /// - Throws: ???
+    ///
+    public func write(from data: NSData) throws {
+
+        if  let socket = socket {
+            try flushStart()
+            if  buffer.length + data.length > HTTPServerResponse.bufferSize  &&  buffer.length != 0  {
+                try socket.write(from: buffer)
+                buffer.length = 0
+            }
+            if  data.length > HTTPServerResponse.bufferSize {
+                try socket.write(from: data)
+            }
+            else {
+                buffer.append(data)
+            }
+        }
+
+    }
+
+    ///
+    /// End the response
+    ///
+    /// - Parameter text: String to write out socket
+    ///
+    /// - Throws: ???
+    ///
+    public func end(text: String) throws {
+        try write(from: text)
+        try end()
+    }
+    
+    ///
+    /// End sending the response
+    ///
+    /// - Throws: ???
+    ///
+    public func end() throws {
+        if let request = serverRequest {
+            request.drain()
+        }
+        if  let socket = socket {
+            try flushStart()
+            if  buffer.length > 0  {
+                try socket.write(from: buffer)
+            }
+            socket.close()
+        }
+        socket = nil
+    }
+
+    ///
+    /// Begin flushing the buffer
+    ///
+    /// - Throws: ???
+    ///
+    private func flushStart() throws {
+
+        if  socket == nil  ||  startFlushed  {
+            return
+        }
+
+        var headerData = ""
+        headerData.append("HTTP/1.1 ")
+        headerData.append(String(status))
+        headerData.append(" ")
+        var statusText = HTTP.statusCodes[status]
+
+        if  statusText == nil {
+            statusText = ""
+        }
+
+        headerData.append(statusText!)
+        headerData.append("\r\n")
+
+        for (key, valueSet) in headers.headers {
+            for value in valueSet {
+                headerData.append(key)
+                headerData.append(": ")
+                headerData.append(value)
+                headerData.append("\r\n")
+            }
+        }
+        // We currently don't support keep alive
+        headerData.append("Connection: Close\r\n")
+
+        headerData.append("\r\n")
+        try writeToSocketThroughBuffer(text: headerData)
+        startFlushed = true
+    }
+
+    ///
+    /// Function to write Strings to the socket through the buffer
+    ///
+    private func writeToSocketThroughBuffer(text: String) throws {
+        guard let socket = socket,
+              let utf8Data = StringUtils.toUtf8String(text) else {
+            return
+        }
+
+        if  buffer.length + utf8Data.length > HTTPServerResponse.bufferSize  &&  buffer.length != 0  {
+            try socket.write(from: buffer)
+            buffer.length = 0
+        }
+        if  utf8Data.length > HTTPServerResponse.bufferSize {
+            try socket.write(from: utf8Data)
+        }
+        else {
+            buffer.append(utf8Data)
+        }
+    }
+}

--- a/Sources/KituraNet/ServerDelegate.swift
+++ b/Sources/KituraNet/ServerDelegate.swift
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+public protocol ServerDelegate: class {
+    func handle(request: ServerRequest, response: ServerResponse)
+}

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -20,7 +20,7 @@ import Socket
 
 // MARK: ServerRequest
 
-public class ServerRequest: IncomingMessage {
+public class ServerRequest: HTTPIncomingMessage {
 
     ///
     /// Socket for the request

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -15,49 +15,77 @@
  **/
 
 import Foundation
-
 import Socket
 
-// MARK: ServerRequest
+//
+// This is a ServerRequest protocol class that allows requests and responses
+// to be abstracted across different protocols in an agnostic way to the 
+// Kitura project Router.
+//
 
-public class ServerRequest: HTTPIncomingMessage {
-
-    ///
-    /// Socket for the request
-    ///
-    private let socket: Socket
-
-    ///
-    /// server IP address pulled from socket
-    ///
-    public var remoteAddress: String {
-        return socket.remoteHostname
-    }
+public protocol ServerRequest: class {
     
     ///
-    /// Initializes a ServerRequest
+    /// Set of headers
     ///
-    /// - Parameter socket: the socket 
-    ///
-    init (socket: Socket) {
-        
-        self.socket = socket
-        super.init(isRequest: true)
-        
-        setup(self)
-    }
-}
-
-/// IncomingMessageHelper protocol extension
-extension ServerRequest: IncomingMessageHelper {
+    var headers : HeadersContainer { get set }
     
     ///
-    /// TODO: ???
+    /// URL
     ///
-    func readHelper(into data: NSMutableData) throws -> Int {
+    var urlString : String { get }
+    
+    ///
+    /// Raw URL
+    ///
+    var url : NSMutableData { get }
 
-        let length = try socket.read(into: data)
-        return length > 0 ? length : (socket.isConnected ? 0 : -1)
-    }
+    ///
+    /// server IP address
+    ///
+    var remoteAddress: String { get }
+    
+    ///
+    /// Major version for HTTP
+    ///
+    var httpVersionMajor: UInt16? { get }
+    
+    
+    ///
+    /// Minor version for HTTP
+    ///
+    var httpVersionMinor: UInt16? { get }
+    
+    ///
+    /// HTTP Method
+    ///
+    var method: String { get }
+    
+    ///
+    /// Read data in the message
+    ///
+    /// - Parameter data: An NSMutableData to hold the data in the message
+    ///
+    /// - Returns: the number of bytes read
+    ///
+    func read(into data: NSMutableData) throws -> Int
+    
+    ///
+    /// Read the string
+    ///
+    /// - Throws: TODO ???
+    /// - Returns: an Optional string
+    ///
+    func readString() throws -> String?
+    
+    
+    ///
+    /// Read all data in the message
+    ///
+    /// - Parameter data: An NSMutableData to hold the data in the message
+    ///
+    /// - Returns: the number of bytes read
+    ///
+    func readAllData(into data: NSMutableData) throws -> Int
     
 }

--- a/Sources/KituraNet/ServerResponse.swift
+++ b/Sources/KituraNet/ServerResponse.swift
@@ -14,75 +14,26 @@
  * limitations under the License.
  **/
 
-import KituraSys
-import Socket
-
 import Foundation
 
-// MARK: ServerResponse
+//
+// This is a ServerResponse protocol class that allows requests and responses
+// to be abstracted across different protocols in an agnostic way to the
+// Kitura project Router.
+//
 
-public class ServerResponse : SocketWriter {
-
-    ///
-    /// Socket for the ServerResponse
-    ///
-    private var socket: Socket?
-
-    ///
-    /// Size of buffer
-    ///
-    private static let bufferSize = 2000
-
-    ///
-    /// Buffer for HTTP response line, headers, and short bodies
-    ///
-    private var buffer: NSMutableData
-
-    ///
-    /// Whether or not the HTTP response line and headers have been flushed.
-    ///
-    private var startFlushed = false
-
-    ///
-    /// TODO: ???
-    ///
-    public var headers = HeadersContainer()
-    
-    ///
-    /// Status code
-    ///
-    private var status = HTTPStatusCode.OK.rawValue
-    
-    ///
-    /// Corresponding server request
-    ///
-    private weak var serverRequest : ServerRequest?
+public protocol ServerResponse: class {
 
     ///
     /// Status code
     ///
-    public var statusCode: HTTPStatusCode? {
-        get {
-            return HTTPStatusCode(rawValue: status)
-        }
-        set (newValue) {
-            if let newValue = newValue where !startFlushed {
-                status = newValue.rawValue
-            }
-        }
-    }
-
+    var statusCode: HTTPStatusCode? { get set }
+    
     ///
-    /// Initializes a ServerResponse instance
+    /// Headers being sent back as part of the HTTP response.
     ///
-    init(socket: Socket, request: ServerRequest) {
-
-        self.socket = socket
-        serverRequest = request
-        buffer = NSMutableData(capacity: ServerResponse.bufferSize)!
-        headers["Date"] = [SPIUtils.httpDate()]
-    }
-
+    var headers : HeadersContainer { get }
+    
     ///
     /// Write a string as a response
     ///
@@ -90,15 +41,8 @@ public class ServerResponse : SocketWriter {
     ///
     /// - Throws: ???
     ///
-    public func write(from string: String) throws {
-
-        if  socket != nil  {
-            try flushStart()
-            try writeToSocketThroughBuffer(text: string)
-        }
-
-    }
-
+    func write(from string: String) throws
+    
     ///
     /// Write data as a response
     ///
@@ -108,24 +52,8 @@ public class ServerResponse : SocketWriter {
     ///
     /// - Throws: ???
     ///
-    public func write(from data: NSData) throws {
-
-        if  let socket = socket {
-            try flushStart()
-            if  buffer.length + data.length > ServerResponse.bufferSize  &&  buffer.length != 0  {
-                try socket.write(from: buffer)
-                buffer.length = 0
-            }
-            if  data.length > ServerResponse.bufferSize {
-                try socket.write(from: data)
-            }
-            else {
-                buffer.append(data)
-            }
-        }
-
-    }
-
+    func write(from data: NSData) throws
+    
     ///
     /// End the response
     ///
@@ -133,88 +61,12 @@ public class ServerResponse : SocketWriter {
     ///
     /// - Throws: ???
     ///
-    public func end(text: String) throws {
-        try write(from: text)
-        try end()
-    }
+    func end(text: String) throws
     
     ///
     /// End sending the response
     ///
     /// - Throws: ???
     ///
-    public func end() throws {
-        if let request = serverRequest {
-            request.drain()
-        }
-        if  let socket = socket {
-            try flushStart()
-            if  buffer.length > 0  {
-                try socket.write(from: buffer)
-            }
-            socket.close()
-        }
-        socket = nil
-    }
-
-    ///
-    /// Begin flushing the buffer
-    ///
-    /// - Throws: ???
-    ///
-    private func flushStart() throws {
-
-        if  socket == nil  ||  startFlushed  {
-            return
-        }
-
-        var headerData = ""
-        headerData.append("HTTP/1.1 ")
-        headerData.append(String(status))
-        headerData.append(" ")
-        var statusText = HTTP.statusCodes[status]
-
-        if  statusText == nil {
-            statusText = ""
-        }
-
-        headerData.append(statusText!)
-        headerData.append("\r\n")
-
-        for (key, valueSet) in headers.headers {
-            for value in valueSet {
-                headerData.append(key)
-                headerData.append(": ")
-                headerData.append(value)
-                headerData.append("\r\n")
-            }
-        }
-        // We currently don't support keep alive
-        headerData.append("Connection: Close\r\n")
-
-        headerData.append("\r\n")
-        try writeToSocketThroughBuffer(text: headerData)
-        startFlushed = true
-    }
-
-    ///
-    /// Function to write Strings to the socket through the buffer
-    ///
-    private func writeToSocketThroughBuffer(text: String) throws {
-        guard let socket = socket,
-              let utf8Data = StringUtils.toUtf8String(text) else {
-            return
-        }
-
-        if  buffer.length + utf8Data.length > ServerResponse.bufferSize  &&  buffer.length != 0  {
-            try socket.write(from: buffer)
-            buffer.length = 0
-        }
-        if  utf8Data.length > ServerResponse.bufferSize {
-            try socket.write(from: utf8Data)
-        }
-        else {
-            buffer.append(utf8Data)
-        }
-    }
+    func end() throws
 }

--- a/Tests/KituraNet/ClientE2ETests.swift
+++ b/Tests/KituraNet/ClientE2ETests.swift
@@ -34,7 +34,7 @@ class ClientE2ETests: XCTestCase {
         doTearDown()
     }
     
-    let delegate = ServerDelegate()
+    let delegate = TestServerDelegate()
     
     func testSimpleHTTPClient() {
         _ = HTTP.get("http://www.ibm.com") {response in
@@ -91,7 +91,7 @@ class ClientE2ETests: XCTestCase {
         })
     }
     
-    class ServerDelegate : HTTPServerDelegate {
+    class TestServerDelegate : ServerDelegate {
     
         func handle(request: ServerRequest, response: ServerResponse) {
             let body = NSMutableData()

--- a/Tests/KituraNet/KituraNetTest.swift
+++ b/Tests/KituraNet/KituraNetTest.swift
@@ -32,7 +32,7 @@ extension KituraNetTest {
         //       sleep(10)
     }
     
-    func performServerTest(_ delegate: HTTPServerDelegate, asyncTasks: (expectation: XCTestExpectation) -> Void...) {
+    func performServerTest(_ delegate: ServerDelegate, asyncTasks: (expectation: XCTestExpectation) -> Void...) {
         let server = setupServer(port: 8090, delegate: delegate)
         let requestQueue = Queue(type: .serial)
         
@@ -65,7 +65,7 @@ extension KituraNetTest {
         req.end()
     }
     
-    private func setupServer(port: Int, delegate: HTTPServerDelegate) -> HTTPServer {
+    private func setupServer(port: Int, delegate: ServerDelegate) -> HTTPServer {
         return HTTPServer.listen(port: port, delegate: delegate,
                                  notOnMainQueue:true)
     }


### PR DESCRIPTION
As the title describes, this is a refactoring / renaming of: 
- The HTTPServerDelegate class protocol in Kitura-net to simply ServerDelegate. 
- The IncomingMessage class to HTTPIncomingMessage
- ServerRequest and ServerResponse into HTTPServerRequest and HTTPServerResponse

There is also a PR against Kitura to support renaming HTTPServerDelegate

All of this is in relation to IBM-Swift/Kitura#565 

## Description
- Pulled HTTPServerDelegate from the HTTPServer class.
- Placed it in it's own file, ServerDelegate.swift in Kitura-net.
- Replaced all uses of HTTPServerDelegate with ServerDelegate system wide. This affects both the Kitura-Net and Kitura projects.
- Renamed IncomingMessage to HTTPIncomingMessage and updated ClientRequest and ServerRequest accordingly.
- Renamed ServerResponse to HTTPServerResponse
- Renamed ServerRequest to HTTPServerRequest
- Created ServerResponse and ServerRequest class protocols so that other modules (Kitura's Router, specifically) can handle response and requests without understanding the underlying protocol (in preperation for FastCGI addition, which will also use the ServerRequest and ServerResponse protocols)
- Modified HTTPServer to directly use HTTPServerResponse and HTTPServerRequest

## Motivation and Context
ServerDelegate will ultimately be used to provide server protocols other than HTTP and will be used by a forthcoming pull request related to adding a FastCGI server implementation to Kitura. For clarity, this refactor makes it obvious that the ServerDelegate handles more than HTTP and moves it out of the HTTPServer class in the process.

Likewise, IncomingMessage is related exclusively to HTTP operation. Refactoring it to HTTPIncomingMessage makes this clear.

Likewise, ServerRequest and ServerResponse were previously exclusive to HTTP operation. By refactoring them to HTTP-prefixed classes and leaving class protocols in their places, it's now clear that they are related to the HTTP server and other protocols (FastCGI specifically) can inject themselves using the same request and response system.

## How Has This Been Tested?
Change is relatively trivial in terms of a refactor. Did a full rebuild of current test projects I'm working on and everything builds and runs as always. There is no real code changes here - just renames/refactors  for the most part. The class protocols mirror the public functions in the original classes so these will sit in for the classes in all calling code without issue (unless something breaks in Swift proper).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
