### PR TITLE
IBM-Swift/Kitura#417 Exploit new dispatch_group APIs in KituraSys to …

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "Kitura-net",
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/Kitura-sys.git", majorVersion: 0, minor: 18),
+        .Package(url: "https://github.com/IBM-Swift/Kitura-sys.git", majorVersion: 0, minor: 21),
         .Package(url: "https://github.com/IBM-Swift/BlueSocket.git", majorVersion: 0, minor: 5),
         .Package(url: "https://github.com/IBM-Swift/CCurl.git", majorVersion: 0, minor: 2),
         .Package(url: "https://github.com/IBM-Swift/CHTTPParser.git", majorVersion: 0, minor: 1),

--- a/Sources/KituraNet/HTTPServer.swift
+++ b/Sources/KituraNet/HTTPServer.swift
@@ -23,6 +23,11 @@ import Socket
 public class HTTPServer {
 
     ///
+    /// Group for waiting on listeners
+    ///
+    private static let listenerGroup = Group()
+
+    ///
     /// Queue for listening and establishing new connections
     ///
     private static var listenerQueue = Queue(type: .parallel, label: "HTTPServer.listenerQueue")
@@ -76,14 +81,26 @@ public class HTTPServer {
 			self.listen(socket: self.listenSocket, port: self.port!)
 		}
 		
+        /** Old code that used the main queue
 		if notOnMainQueue {
 			HTTPServer.listenerQueue.enqueueAsynchronously(queuedBlock)
 		}
 		else {
 			Queue.enqueueIfFirstOnMain(queue: HTTPServer.listenerQueue, block: queuedBlock)
 		}
+        **/
+        
+        HTTPServer.listenerGroup.enqueueAsynchronously(on: HTTPServer.listenerQueue, block: queuedBlock)
         
     }
+    
+    ///
+    /// Wait for all of the listeners to stop
+    ///
+    public static func waitForListeners() {
+        listenerGroup.wait(for: .ever)
+    }
+
 
     ///
     /// Stop listening for new connections


### PR DESCRIPTION

## Description
HTTP listener blocks are now queued for execution within a dispatch_group. In addition an API is exposed to enable others to wait on the dispatch_group used. They are never queued onto the main queue.

Using this new API there is no longer a need to call dispatch_main.

**Note:** It is important that this PR not be merged before the PR https://github.com/IBM-Swift/Kitura-sys/pull/5 is merged.

## Motivation and Context
On Linux processes running Kitura used to get marked as defunct. This prevented:
  1. The use of LLDB to debug
  2. Getting core files when Kitura crashed
  3. Tools like top didn't report useful information

This was apparently due to the way dispatch_main is implemented on Linux.

This is issue IBM-Swift/Kitura#417

## How Has This Been Tested?
Tested as part of the performance test work, ran Kitura under lldb, and have successfully gotten core files when Kitura processes crash.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.