### PR TITLE
FastCGI Protocol Support and Tests

### DIFF
--- a/Sources/KituraNet/FastCGI.swift
+++ b/Sources/KituraNet/FastCGI.swift
@@ -1,0 +1,77 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+public class FastCGI {
+ 
+    //
+    // Global Constants we Need
+    //
+    struct Constants {
+        // general
+        static let FASTCGI_PROTOCOL_VERSION : UInt8 = 1
+        static let FASTCGI_DEFAULT_REQUEST_ID : UInt16 = 0
+        
+        // reecord types
+        static let FCGI_NO_TYPE : UInt8 = 0
+        static let FCGI_BEGIN_REQUEST : UInt8 = 1
+        static let FCGI_END_REQUEST : UInt8 = 3
+        static let FCGI_PARAMS : UInt8 = 4
+        static let FCGI_STDIN : UInt8 = 5
+        static let FCGI_STDOUT : UInt8 = 6
+        
+        // sub types
+        static let FCGI_SUBTYPE_NO_TYPE : UInt8 = 69
+        static let FCGI_REQUEST_COMPLETE : UInt8 = 0
+        static let FCGI_CANT_MPX_CONN : UInt8 = 1
+        static let FCGI_UNKNOWN_ROLE : UInt8 = 3
+        
+        // roles
+        static let FCGI_NO_ROLE : UInt16 = 69
+        static let FCGI_RESPONDER : UInt16 = 1
+        
+        // flags
+        static let FCGI_KEEP_CONN : UInt8 = 1
+        
+        // request headers of note
+        static let HEADER_REQUEST_METHOD : String = "REQUEST_METHOD";
+        static let HEADER_REQUEST_SCHEME : String = "REQUEST_SCHEME";
+        static let HEADER_HTTP_HOST : String = "HTTP_HOST";
+        static let HEADER_REQUEST_URI : String = "REQUEST_URI";
+    }
+    
+    //
+    // Exceptions
+    //
+    enum RecordErrors : ErrorProtocol {
+        case InvalidType
+        case InvalidSubType
+        case InvalidRequestId
+        case InvalidRole
+        case OversizeData
+        case InvalidVersion
+        case EmptyParams
+        case BufferExhausted
+        case UnsupportedRole
+    }
+
+    // Create a Server
+    //
+    public static func createServer() -> FastCGIServer {
+        return FastCGIServer()
+    }
+
+    
+}

--- a/Sources/KituraNet/FastCGI.swift
+++ b/Sources/KituraNet/FastCGI.swift
@@ -70,7 +70,7 @@ public class FastCGI {
         case invalidRole
         case oversizeData
         case invalidVersion
-        case emptyParams
+        case emptyParameters
         case bufferExhausted
         case unsupportedRole
         case internalError

--- a/Sources/KituraNet/FastCGI.swift
+++ b/Sources/KituraNet/FastCGI.swift
@@ -17,14 +17,17 @@
 public class FastCGI {
  
     //
-    // Global Constants we Need
+    // Global Constants used through FastCGI protocol implementation
     //
     struct Constants {
+        
         // general
+        //
         static let FASTCGI_PROTOCOL_VERSION : UInt8 = 1
         static let FASTCGI_DEFAULT_REQUEST_ID : UInt16 = 0
         
-        // reecord types
+        // FastCGI record types
+        //
         static let FCGI_NO_TYPE : UInt8 = 0
         static let FCGI_BEGIN_REQUEST : UInt8 = 1
         static let FCGI_END_REQUEST : UInt8 = 3
@@ -33,19 +36,24 @@ public class FastCGI {
         static let FCGI_STDOUT : UInt8 = 6
         
         // sub types
-        static let FCGI_SUBTYPE_NO_TYPE : UInt8 = 69
+        //
+        static let FCGI_SUBTYPE_NO_TYPE : UInt8 = 99
         static let FCGI_REQUEST_COMPLETE : UInt8 = 0
         static let FCGI_CANT_MPX_CONN : UInt8 = 1
         static let FCGI_UNKNOWN_ROLE : UInt8 = 3
         
         // roles
-        static let FCGI_NO_ROLE : UInt16 = 69
+        //
+        static let FCGI_NO_ROLE : UInt16 = 99
         static let FCGI_RESPONDER : UInt16 = 1
         
         // flags
+        //
         static let FCGI_KEEP_CONN : UInt8 = 1
         
         // request headers of note
+        // we translate these into internal variables
+        //
         static let HEADER_REQUEST_METHOD : String = "REQUEST_METHOD";
         static let HEADER_REQUEST_SCHEME : String = "REQUEST_SCHEME";
         static let HEADER_HTTP_HOST : String = "HTTP_HOST";
@@ -68,6 +76,8 @@ public class FastCGI {
     }
 
     // Create a Server
+    // Provided as a convenience and a consistency 
+    // with the HTTP implementation.
     //
     public static func createServer() -> FastCGIServer {
         return FastCGIServer()

--- a/Sources/KituraNet/FastCGI.swift
+++ b/Sources/KituraNet/FastCGI.swift
@@ -64,17 +64,17 @@ public class FastCGI {
     // Exceptions
     //
     enum RecordErrors : ErrorProtocol {
-        case InvalidType
-        case InvalidSubType
-        case InvalidRequestId
-        case InvalidRole
-        case OversizeData
-        case InvalidVersion
-        case EmptyParams
-        case BufferExhausted
-        case UnsupportedRole
-        case InternalError
-        case ProtocolError
+        case invalidType
+        case invalidSubType
+        case invalidRequestId
+        case invalidRole
+        case oversizeData
+        case invalidVersion
+        case emptyParams
+        case bufferExhausted
+        case unsupportedRole
+        case internalError
+        case protocolError
     }
 
     // Create a Server

--- a/Sources/KituraNet/FastCGIRecordCreate.swift
+++ b/Sources/KituraNet/FastCGIRecordCreate.swift
@@ -1,0 +1,361 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#if os(Linux)
+    import Foundation
+    import Glibc
+#else
+    import Darwin
+    import Foundation
+#endif
+
+class FastCGIRecordCreate {
+    
+    //
+    // variables
+    //
+    var recordType : UInt8
+    var protocolStatus : UInt8
+    var requestId : UInt16    
+    var data : NSData?
+    var requestRole : UInt16
+    var keepAlive : Bool
+    var params : [(String,String)] = []
+    
+    // 
+    // init for making a new record
+    //
+    init() {
+        self.recordType = FastCGI.Constants.FCGI_NO_TYPE
+        self.protocolStatus = FastCGI.Constants.FCGI_SUBTYPE_NO_TYPE
+        self.requestId = FastCGI.Constants.FASTCGI_DEFAULT_REQUEST_ID
+        self.data = nil
+        self.requestRole = FastCGI.Constants.FCGI_NO_ROLE
+        self.keepAlive = false
+    }
+    
+    //
+    // Write one or more zero bytes to a Data object
+    //
+    private func writeZero(data: NSMutableData, count: Int) {
+        var zeroByte : UInt8 = 0
+        for _ in 1...count {
+            data.append(&zeroByte, length: 1)
+        }
+    }
+    
+    // Helper to turn UInt16 from local to network.
+    //
+    private static func networkByteOrderSmall(_ from: UInt16) -> UInt16 {
+        #if os(Linux)
+            return Glibc.htons(from)
+        #else
+            return CFSwapInt16HostToBig(from)
+        #endif
+    }
+    
+    // Helper to turn UInt32 from local to network.
+    //
+    private static func networkByteOrderLarge(_ from: UInt32) -> UInt32 {
+        #if os(Linux)
+            return Glibc.htonl(from)
+        #else
+            return CFSwapInt32HostToBig(from)
+        #endif
+    }
+    
+    //
+    // Create the shared starting portion of a FastCGI,
+    // shared by all FastCGI records we'll be generating
+    //
+    private func createRecordStarter() -> NSMutableData {
+        let r = NSMutableData();
+        
+        var v : UInt8 = FastCGI.Constants.FASTCGI_PROTOCOL_VERSION
+        var t : UInt8 = self.recordType
+        var requestId : UInt16 = FastCGIRecordCreate.networkByteOrderSmall(self.requestId)
+        
+        r.append(&v, length: 1);
+        r.append(&t, length: 1);
+        r.append(&requestId, length: 2)
+        
+        return r;
+    }
+    
+    //
+    // Generate an "END REQUEST" record of subtype "COMPLETE"
+    //
+    private func finalizeRequestCompleteRecord(data: NSMutableData) -> NSData {
+        
+        var contentLength : UInt16 = FastCGIRecordCreate.networkByteOrderSmall(UInt16(8))
+        var protocolStatus : UInt8 = self.protocolStatus
+        
+        // content length
+        data.append(&contentLength, length: 2)
+        
+        // padding length
+        writeZero(data: data, count: 1)
+        
+        // reserved space
+        writeZero(data: data, count: 1)
+        
+        // application id - we don't use this
+        writeZero(data: data, count: 4)
+        
+        // protocol status
+        data.append(&protocolStatus, length: 1)
+
+        // reserved space
+        writeZero(data: data, count: 3)
+        
+        return data
+    }
+    
+    //
+    // Generate a "BEGIN REQUEST" record
+    //
+    private func finalizeRequestBeginRecord(data: NSMutableData) -> NSData {
+        
+        var contentLength : UInt16 = FastCGIRecordCreate.networkByteOrderSmall(8)
+        var requestRole : UInt16 = FastCGIRecordCreate.networkByteOrderSmall(self.requestRole)
+        var flags : UInt8 = self.keepAlive ? (0 | FastCGI.Constants.FCGI_KEEP_CONN) : 0
+        
+        // content length
+        data.append(&contentLength, length: 2)
+        
+        // padding length
+        writeZero(data: data, count: 1)
+        
+        // reserved space
+        writeZero(data: data, count: 1)
+        
+        // request role
+        data.append(&requestRole, length: 2)
+        
+        // flags
+        data.append(&flags, length: 1)
+        
+        // reserved space
+        writeZero(data: data, count: 5)
+        
+        return data
+    }
+    
+    //
+    // Write encoded length (8 bit or 4x8bit) for a param record
+    //
+    private func writeEncodedLength(length: Int, into: NSMutableData) {
+        
+        if (length > 127) {
+            var encodedLength : UInt32 = FastCGIRecordCreate.networkByteOrderLarge(UInt32(length)) | ~0xffffff7f
+            into.append(&encodedLength, length: 4)
+        }
+        else {
+            var encodedLength : UInt8 = UInt8(length)
+            into.append(&encodedLength, length: 1)
+        }
+        
+    }
+    
+    //
+    // Generate parameter records
+    //
+    private func createParameterRecords() -> NSData {
+        
+        let content : NSMutableData = NSMutableData()
+        
+        for (key, value) in self.params {
+
+            // generate our key and value
+            let keyData : NSData? = key.data(using: NSUTF8StringEncoding)
+            let valueData : NSData? = value.data(using: NSUTF8StringEncoding)
+
+            guard keyData != nil else {
+                continue
+            }
+            
+            guard valueData != nil else {
+                continue
+            }
+            
+            self.writeEncodedLength(length: keyData!.length, into: content)
+            self.writeEncodedLength(length: valueData!.length, into: content)
+            
+            content.append(keyData!)
+            content.append(valueData!)
+            
+        }
+        
+        return content;
+    }
+    
+    //
+    // Generate a parameters (PARAMS) record
+    //
+    private func finalizeParams(data: NSMutableData) -> NSData {
+        self.data = self.createParameterRecords()
+        return self.finalizeDataRecord(data: data)
+    }
+    
+    //
+    // Generate a data (STDOUT) record
+    //
+    private func finalizeDataRecord(data: NSMutableData) -> NSData {
+        
+        let contentData : NSData = self.data == nil ? NSData() : self.data!
+        var contentLength : UInt16 = FastCGIRecordCreate.networkByteOrderSmall(UInt16(contentData.length))
+        
+        // note that we will align all of our data structures to 8 bytes
+        var paddingLength : Int = Int(contentData.length % 8)
+        
+        if (paddingLength > 0) {
+            paddingLength = 8 - paddingLength
+        }
+
+        var paddingLengthEncoded : UInt8 = UInt8(paddingLength)
+
+        data.append(&contentLength, length: 2)
+        data.append(&paddingLengthEncoded, length: 1)
+        
+        // reserved space
+        self.writeZero(data: data, count: 1)
+        // write our data block
+        data.append(contentData)
+        
+        // write any padding
+        if (paddingLength > 0) {
+            self.writeZero(data: data, count: paddingLength)
+        }
+        
+        return data
+    }
+    
+    //
+    // Test the internal record for sanity before generation
+    //
+    private func recordTest() throws -> Void {
+        
+        // check that our record type is ok
+        //
+        var recordTypeOk : Bool = false
+        
+        if (self.recordType == FastCGI.Constants.FCGI_END_REQUEST) {
+            recordTypeOk = true
+        } else if (self.recordType == FastCGI.Constants.FCGI_STDOUT) {
+            recordTypeOk = true
+        } else if (self.recordType == FastCGI.Constants.FCGI_STDIN) {
+            recordTypeOk = true
+        } else if (self.recordType == FastCGI.Constants.FCGI_PARAMS) {
+            recordTypeOk = true
+        } else if (self.recordType == FastCGI.Constants.FCGI_BEGIN_REQUEST) {
+            recordTypeOk = true
+        }
+        
+        guard recordTypeOk else {
+            throw FastCGI.RecordErrors.InvalidType
+        }
+        
+        // check that our subtype is ok, if applicable
+        //
+        if self.recordType == FastCGI.Constants.FCGI_END_REQUEST {
+            
+            var subRecordTypeOk : Bool = false
+            
+            if (self.protocolStatus == FastCGI.Constants.FCGI_REQUEST_COMPLETE) {
+                subRecordTypeOk = true
+            }
+            else if (self.protocolStatus == FastCGI.Constants.FCGI_CANT_MPX_CONN) {
+                subRecordTypeOk = true
+            }
+            else if (self.protocolStatus == FastCGI.Constants.FCGI_UNKNOWN_ROLE) {
+                subRecordTypeOk = true
+            }
+            
+            guard subRecordTypeOk else {
+                throw FastCGI.RecordErrors.InvalidSubType
+            }
+            
+        }
+        else if self.recordType == FastCGI.Constants.FCGI_BEGIN_REQUEST {
+            
+            var roleOk : Bool = false
+            
+            // we only support one role right now
+            if self.requestRole == FastCGI.Constants.FCGI_RESPONDER {
+                roleOk = true
+            }
+            
+            guard roleOk else {
+                throw FastCGI.RecordErrors.InvalidRole
+            }
+            
+        }
+        else if self.recordType == FastCGI.Constants.FCGI_PARAMS {
+            
+            guard self.params.count > 0 else {
+                throw FastCGI.RecordErrors.EmptyParams
+            }
+            
+        }
+        
+        // check that our request id is valid
+        //
+        guard self.requestId != FastCGI.Constants.FASTCGI_DEFAULT_REQUEST_ID else {
+            throw FastCGI.RecordErrors.InvalidRequestId
+        }
+        
+        // check that our data object, if any, isn't larger 
+        // than 16-bits addressable worth of data
+        //
+        if (self.data != nil) {
+            guard self.data!.length <= 65535 else {
+                throw FastCGI.RecordErrors.OversizeData
+            }
+        }
+        
+    }
+        
+    //
+    // Generate the record currently contained by the class
+    //
+    func create() throws -> NSData {
+        
+        // rely on throw to abort if there is an issue
+        try recordTest();
+        
+        let record : NSMutableData = self.createRecordStarter()
+        
+        if self.recordType == FastCGI.Constants.FCGI_BEGIN_REQUEST {
+            return self.finalizeRequestBeginRecord(data: record)
+        }
+        else if self.recordType == FastCGI.Constants.FCGI_END_REQUEST {
+            return self.finalizeRequestCompleteRecord(data: record)
+        }
+        else if self.recordType == FastCGI.Constants.FCGI_PARAMS {
+            return self.finalizeParams(data: record)
+        }
+        else if self.recordType == FastCGI.Constants.FCGI_STDOUT || self.recordType == FastCGI.Constants.FCGI_STDIN {
+            return self.finalizeDataRecord(data: record)
+        }
+        else {
+            // this will never happen as the recordTest() prevented it 
+            // but it keeps the compiler from complaining.
+            throw FastCGI.RecordErrors.InvalidType
+        }
+        
+    }
+    
+}

--- a/Sources/KituraNet/FastCGIRecordCreate.swift
+++ b/Sources/KituraNet/FastCGIRecordCreate.swift
@@ -253,7 +253,7 @@ class FastCGIRecordCreate {
             break
             
         default:
-            throw FastCGI.RecordErrors.InvalidType
+            throw FastCGI.RecordErrors.invalidType
         }
         
         // check that our subtype is ok, if applicable
@@ -267,14 +267,14 @@ class FastCGIRecordCreate {
                 break
                 
             default:
-                throw FastCGI.RecordErrors.InvalidSubType
+                throw FastCGI.RecordErrors.invalidSubType
             }
             
         }
         else if self.recordType == FastCGI.Constants.FCGI_BEGIN_REQUEST {
             
             guard self.requestRole == FastCGI.Constants.FCGI_RESPONDER else {
-                throw FastCGI.RecordErrors.InvalidRole
+                throw FastCGI.RecordErrors.invalidRole
             }
             
         }
@@ -282,7 +282,7 @@ class FastCGIRecordCreate {
         // check that our request id is valid
         //
         guard self.requestId != FastCGI.Constants.FASTCGI_DEFAULT_REQUEST_ID else {
-            throw FastCGI.RecordErrors.InvalidRequestId
+            throw FastCGI.RecordErrors.invalidRequestId
         }
         
         // check that our data object, if any, isn't larger 
@@ -292,7 +292,7 @@ class FastCGIRecordCreate {
             return
         }
         guard data.length <= 65535 else {
-            throw FastCGI.RecordErrors.OversizeData
+            throw FastCGI.RecordErrors.oversizeData
         }
         
     }

--- a/Sources/KituraNet/FastCGIRecordCreate.swift
+++ b/Sources/KituraNet/FastCGIRecordCreate.swift
@@ -34,7 +34,7 @@ class FastCGIRecordCreate {
     var data : NSData?
     var requestRole : UInt16 = FastCGI.Constants.FCGI_NO_ROLE
     var keepAlive : Bool = false
-    var params : [(String,String)] = []
+    var parameters : [(String,String)] = []
     
     //
     // Append one or more zero bytes to the provided NSMutableData object
@@ -170,7 +170,7 @@ class FastCGIRecordCreate {
         
         let content : NSMutableData = NSMutableData()
         
-        for (key, value) in self.params {
+        for (key, value) in self.parameters {
 
             // generate our key and value by converting to 
             // Data from String using UTF-8.
@@ -199,7 +199,7 @@ class FastCGIRecordCreate {
     //
     // Generate a parameters (PARAMS) record
     //
-    private func finalizeParams(data: NSMutableData) -> NSData {
+    private func finalizeParameters(data: NSMutableData) -> NSData {
         self.data = self.createParameterRecords()
         return self.finalizeDataRecord(data: data)
     }
@@ -315,7 +315,7 @@ class FastCGIRecordCreate {
             return self.finalizeRequestCompleteRecord(data: record)
             
         case FastCGI.Constants.FCGI_PARAMS:
-            return self.finalizeParams(data: record)
+            return self.finalizeParameters(data: record)
             
         default:
             // either STDIN or STDOUT

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -1,0 +1,376 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#if os(Linux)
+    import Foundation
+    import Glibc
+#else
+    import Darwin
+    import Foundation
+#endif
+
+import KituraSys
+
+class FastCGIRecordParser {
+    
+    // Variables
+    //
+    var version : UInt8 = 0
+    var type : UInt8 = 0
+    var requestId : UInt16 = 0
+    var role : UInt16 = 0
+    var flags : UInt8 = 0
+    var headers : [Dictionary] = Array<Dictionary<String,String>>()
+    var data : NSData? = nil
+    var appStatus : UInt32 = 0
+    var protocolStatus : UInt8 = 0
+    
+    var keepalive : Bool {
+        return self.flags & FastCGI.Constants.FCGI_KEEP_CONN == 0 ? false : true
+    }
+    
+    // Internal Variables
+    //
+    private var contentLength : UInt16 = 0
+    private var paddingLength : UInt8 = 0
+    private var pointer : Int = 0
+    private var buffer : NSData
+    private var bufferBytes : UnsafePointer<UInt8>
+    
+    // Pointer
+    //
+    func advance() throws -> Int {
+        
+        guard self.pointer < self.buffer.length else {
+            throw FastCGI.RecordErrors.BufferExhausted
+        }
+        
+        let r = self.pointer
+        self.pointer = self.pointer + 1
+        return r
+    }
+    
+    func skip(_ count: Int) throws {
+        self.pointer = self.pointer + count
+        
+        // because we're skipping, it's ok to be pointer=length because we 
+        // may never be reading again. but pointer=(length+x) is bad (where x>0)
+        // because it means there aren't the bytes we expected
+        //
+        guard self.pointer <= self.buffer.length else {
+            throw FastCGI.RecordErrors.BufferExhausted
+        }
+    }
+    
+    // Helper to turn UInt16 from network to local.
+    //
+    private static func localByteOrderSmall(_ from: UInt16) -> UInt16 {
+        #if os(Linux)
+            return Glibc.ntohs(from)
+        #else
+            return CFSwapInt16BigToHost(from)
+        #endif
+    }
+    
+    // Helper to turn UInt32 from network to local.
+    //
+    private static func localByteOrderLarge(_ from: UInt32) -> UInt32 {
+        #if os(Linux)
+            return Glibc.ntohl(from)
+        #else
+            return CFSwapInt32BigToHost(from)
+        #endif
+    }
+    
+    // Initialize
+    //
+    init(_ data: NSData) {
+        self.buffer = data
+        self.bufferBytes = UnsafePointer<UInt8>(data.bytes)
+    }
+    
+    //
+    // Parse FastCGI Version
+    //
+    private func parseVersion() throws {
+        self.version = self.bufferBytes[try advance()]
+        
+        guard self.version == FastCGI.Constants.FASTCGI_PROTOCOL_VERSION else {
+            throw FastCGI.RecordErrors.InvalidVersion
+        }
+    }
+    
+    // Parse record type.
+    //
+    private func parseType() throws {
+        
+        self.type = self.bufferBytes[try advance()]
+        
+        var typeOk : Bool = false
+        
+        switch (self.type) {
+        case FastCGI.Constants.FCGI_BEGIN_REQUEST:
+            typeOk = true;
+            break;
+        case FastCGI.Constants.FCGI_END_REQUEST:
+            typeOk = true;
+            break;
+        case FastCGI.Constants.FCGI_PARAMS:
+            typeOk = true;
+            break;
+        case FastCGI.Constants.FCGI_STDIN:
+            typeOk = true;
+            break;
+        case FastCGI.Constants.FCGI_STDOUT:
+            typeOk = true;
+            break;
+        default:
+            typeOk = false;
+            break;
+        }
+        
+        guard typeOk else {
+            throw FastCGI.RecordErrors.InvalidType
+        }
+        
+    }
+    
+    // Parse request ID
+    //
+    private func parseRequestId() throws {
+        
+        let requestIdBytes1 = self.bufferBytes[try advance()]
+        let requestIdBytes0 = self.bufferBytes[try advance()]
+        let requestIdBytes : [UInt8] = [ requestIdBytes1, requestIdBytes0 ]
+        
+        self.requestId = FastCGIRecordParser.localByteOrderSmall(UnsafePointer<UInt16>(requestIdBytes).pointee)
+        
+    }
+
+    // Parse content length.
+    //
+    private func parseContentLength() throws {
+        
+        let contentLengthBytes1 = self.bufferBytes[try advance()]
+        let contentLengthBytes0 = self.bufferBytes[try advance()]
+        let contentLengthBytes : [UInt8] = [ contentLengthBytes1, contentLengthBytes0 ]
+        
+        self.contentLength = FastCGIRecordParser.localByteOrderSmall(UnsafePointer<UInt16>(contentLengthBytes).pointee)
+        
+    }
+    
+    // Parse padding length
+    //
+    private func parsePaddingLength() throws {
+        self.paddingLength = self.bufferBytes[try advance()]
+    }
+
+    // Parse a role
+    //
+    private func parseRole() throws {
+        
+        let roleByte1 = self.bufferBytes[try advance()]
+        let roleByte0 = self.bufferBytes[try advance()]
+        let roleBytes : [UInt8] = [ roleByte1, roleByte0 ]
+        
+        self.role = FastCGIRecordParser.localByteOrderSmall(UnsafePointer<UInt16>(roleBytes).pointee)
+        self.flags = self.bufferBytes[try advance()]
+
+        guard self.role == FastCGI.Constants.FCGI_RESPONDER else {
+            throw FastCGI.RecordErrors.UnsupportedRole
+        }
+        
+    }
+    
+    // Parse an app status
+    //
+    private func parseAppStatus() throws {
+        
+        let appStatusByte3 = self.bufferBytes[try advance()]
+        let appStatusByte2 = self.bufferBytes[try advance()]
+        let appStatusByte1 = self.bufferBytes[try advance()]
+        let appStatusByte0 = self.bufferBytes[try advance()]
+        let appStatusBytes : [UInt8] = [ appStatusByte3, appStatusByte2, appStatusByte1, appStatusByte0 ]
+        
+        self.appStatus = FastCGIRecordParser.localByteOrderLarge(UnsafePointer<UInt32>(appStatusBytes).pointee)
+    
+    }
+    
+    // Parse a protocol status
+    //
+    private func parseProtocolStatus() throws {
+        self.protocolStatus = self.bufferBytes[try advance()]
+    }
+    
+    // Parse raw data from a data record
+    //
+    private func parseData() throws {
+        if (self.contentLength > 0) {
+            self.data = NSData(bytes: self.bufferBytes+pointer, length: Int(self.contentLength))
+            try skip(Int(self.contentLength))
+        } else {
+            self.data = NSData()
+        }
+    }
+    
+    //
+    // The following functions parse the parameter blocks.
+    // Because parameter blocks can be encoded sequentially
+    // in a single record this is more complex than simply 
+    // extracting blocks from a single record - hance the 
+    // extra functions involved.
+    //
+    
+    //
+    // The parameter name/value length encoding scheme used by FastCGI
+    // is interesting. Basically, it lets 1 byte be used to encode lengths
+    // less than 127 bytes, but allocates 4 bytes to encode the length
+    // of anything larger. We determine what state we're in by checking
+    // the higher order bit of the first byte in the length. off = 127 or less,
+    // on = 128 or larger.
+    //
+    // If we are using 4 bytes for a length value, we need to mask
+    // the first byte with 0x7f when assembling it back into a 32-bit length
+    // value.
+    //
+    //
+    private func parseParameterLength() throws -> Int {
+        
+        let lengthPeek : UInt8 = self.bufferBytes[try advance()]
+        
+        if (lengthPeek >> 7 == 0) {
+            return Int(lengthPeek)
+        } else {
+            let lengthByteB3 : UInt8 = lengthPeek
+            let lengthByteB2 : UInt8 = self.bufferBytes[try advance()]
+            let lengthByteB1 : UInt8 = self.bufferBytes[try advance()]
+            let lengthByteB0 : UInt8 = self.bufferBytes[try advance()]
+            let lengthBytes : [UInt8] = [ lengthByteB3 & 0x7f, lengthByteB2, lengthByteB1, lengthByteB0 ]
+
+            return Int(FastCGIRecordParser.localByteOrderLarge(UnsafePointer<UInt32>(lengthBytes).pointee))
+        }
+        
+    }
+    
+    // Parse a parameter block
+    //
+    private func parseParams() throws {
+        
+        guard self.contentLength > 0 else {
+            return;
+        }
+        
+        var contentRemaining : Int = Int(self.contentLength)
+        
+        repeat {
+            let initialPointer : Int = self.pointer
+            let nameLength : Int = try self.parseParameterLength()
+            let valueLength : Int = try self.parseParameterLength()
+            var nameString : String!
+            var valueString : String!
+            
+            // capture a name if needed
+            if (nameLength > 0) {
+                let currentPointer : Int = pointer
+                try skip(nameLength)
+                let nameData = NSData(bytes: self.bufferBytes+currentPointer, length: nameLength)
+                nameString = String(data: nameData, encoding: NSUTF8StringEncoding)
+            } else {
+                nameString = ""
+            }
+            
+            if (nameString == nil || (nameString.characters.count == 0 && nameLength > 0)) {
+                throw FastCGI.RecordErrors.EmptyParams
+            }
+            
+            // capture a value if needed
+            if (valueLength > 0) {
+                let currentPointer : Int = pointer
+                try skip(valueLength)
+                let valueData = NSData(bytes: self.bufferBytes+currentPointer, length: valueLength)
+                valueString = String(data: valueData, encoding: NSUTF8StringEncoding)
+            } else {
+                valueString = ""
+            }
+
+            if (valueString == nil) {
+                throw FastCGI.RecordErrors.EmptyParams
+            }
+
+            // all good - store it
+            self.headers.append(["name": nameString!, "value": valueString!])
+            
+            // adjust our position
+            contentRemaining = contentRemaining - (self.pointer - initialPointer)
+            
+        }
+        while (contentRemaining > 0)
+        
+    }
+    
+    // Skip any padding indicated, then return the unused portion
+    // of our data buffer. We're done reading this record.
+    //
+    private func skipPaddingThenReturn() throws -> NSMutableData {
+        
+        if (self.paddingLength > 0) {
+            try skip(Int(self.paddingLength))
+        }
+        
+        let remainingBufferBytes = self.buffer.length - self.pointer
+        
+        if (remainingBufferBytes == 0) {
+            return NSMutableData()
+        } else {
+            return NSMutableData(bytes: buffer.bytes+self.pointer, length: remainingBufferBytes)
+        }
+        
+    }
+    
+    // Parser the data, return any extra
+    //
+    func parse() throws -> NSMutableData {
+        
+        // make parser go now!        
+        try parseVersion()
+        try parseType()
+        try parseRequestId()
+        try parseContentLength()
+        try parsePaddingLength()
+        try skip(1)
+        
+        if (self.type == FastCGI.Constants.FCGI_BEGIN_REQUEST) {
+            try parseRole()
+            try skip(5)
+        } else if (self.type == FastCGI.Constants.FCGI_END_REQUEST) {
+            try parseAppStatus()
+            try parseProtocolStatus()
+            try skip(3)
+        } else if (self.type == FastCGI.Constants.FCGI_PARAMS) {
+            try parseParams()
+        } else if (self.type == FastCGI.Constants.FCGI_STDIN) {
+            try parseData()
+        } else if (self.type == FastCGI.Constants.FCGI_STDOUT) {
+            try parseData()
+        }
+        
+        // return new data object representing any data
+        // not part of the parsed record
+        return try skipPaddingThenReturn()
+    }
+    
+    
+}

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -63,7 +63,7 @@ class FastCGIRecordParser {
         }
         
         let r = self.pointer
-        self.pointer = self.pointer + 1
+        self.pointer += 1
         return r
     }
     
@@ -73,7 +73,8 @@ class FastCGIRecordParser {
     // the valid bounds.
     //
     func skip(_ count: Int) throws {
-        self.pointer = self.pointer + count
+        
+        self.pointer += count
         
         // because we're skipping, it's ok to be pointer=length because we 
         // may never be reading again. but pointer=(length+x) is bad (where x>0)
@@ -232,7 +233,7 @@ class FastCGIRecordParser {
     //
     private func parseData() throws {
         if self.contentLength > 0 {
-            self.data = NSData(bytes: self.bufferBytes+pointer, length: Int(self.contentLength))
+            self.data = NSData(bytes: self.bufferBytes + pointer, length: Int(self.contentLength))
             try skip(Int(self.contentLength))
         } else {
             self.data = NSData()
@@ -315,7 +316,7 @@ class FastCGIRecordParser {
             
             let currentPointer : Int = pointer
             try skip(nameLength)
-            let nameData = NSData(bytes: self.bufferBytes+currentPointer, length: nameLength)
+            let nameData = NSData(bytes: self.bufferBytes + currentPointer, length: nameLength)
             
             guard let nameString = StringUtils.fromUtf8String(nameData) else {
                 // the data received from the web server couldn't be transcoded
@@ -338,7 +339,7 @@ class FastCGIRecordParser {
                 
                 let currentPointer : Int = pointer
                 try skip(valueLength)
-                let valueData = NSData(bytes: self.bufferBytes+currentPointer, length: valueLength)
+                let valueData = NSData(bytes: self.bufferBytes + currentPointer, length: valueLength)
                 
                 guard let valueString = StringUtils.fromUtf8String(valueData) else {
                     // a value was supposed to have been provided but decoding it
@@ -380,7 +381,7 @@ class FastCGIRecordParser {
         if remainingBufferBytes == 0 {
             return NSMutableData()
         } else {
-            return NSMutableData(bytes: buffer.bytes+self.pointer, length: remainingBufferBytes)
+            return NSMutableData(bytes: buffer.bytes + self.pointer, length: remainingBufferBytes)
         }
         
     }

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -89,11 +89,11 @@ class FastCGIRecordParser {
     // Helper to turn UInt16 from network byte order to local byte order,
     // which is typically Big to Little.
     //
-    private static func localByteOrderSmall(_ from: UInt16) -> UInt16 {
+    private static func getLocalByteOrderSmall(from networkOrderedBytes: UInt16) -> UInt16 {
         #if os(Linux)
-            return Glibc.ntohs(from)
+            return Glibc.ntohs(networkOrderedBytes)
         #else
-            return CFSwapInt16BigToHost(from)
+            return CFSwapInt16BigToHost(networkOrderedBytes)
         #endif
     }
     
@@ -101,11 +101,11 @@ class FastCGIRecordParser {
     // Helper to turn UInt32 from network byte order to local byte order,
     // which is typically Big to Little.
     //
-    private static func localByteOrderLarge(_ from: UInt32) -> UInt32 {
+    private static func getLocalByteOrderLarge(from networkOrderedBytes: UInt32) -> UInt32 {
         #if os(Linux)
-            return Glibc.ntohl(from)
+            return Glibc.ntohl(networkOrderedBytes)
         #else
-            return CFSwapInt32BigToHost(from)
+            return CFSwapInt32BigToHost(networkOrderedBytes)
         #endif
     }
     
@@ -155,7 +155,7 @@ class FastCGIRecordParser {
         let requestIdBytes0 = self.bufferBytes[try advance()]
         let requestIdBytes : [UInt8] = [ requestIdBytes1, requestIdBytes0 ]
         
-        self.requestId = FastCGIRecordParser.localByteOrderSmall(UnsafePointer<UInt16>(requestIdBytes).pointee)
+        self.requestId = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(requestIdBytes).pointee)
         
     }
 
@@ -167,7 +167,7 @@ class FastCGIRecordParser {
         let contentLengthBytes0 = self.bufferBytes[try advance()]
         let contentLengthBytes : [UInt8] = [ contentLengthBytes1, contentLengthBytes0 ]
         
-        self.contentLength = FastCGIRecordParser.localByteOrderSmall(UnsafePointer<UInt16>(contentLengthBytes).pointee)
+        self.contentLength = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(contentLengthBytes).pointee)
         
     }
     
@@ -185,7 +185,7 @@ class FastCGIRecordParser {
         let roleByte0 = self.bufferBytes[try advance()]
         let roleBytes : [UInt8] = [ roleByte1, roleByte0 ]
         
-        self.role = FastCGIRecordParser.localByteOrderSmall(UnsafePointer<UInt16>(roleBytes).pointee)
+        self.role = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(roleBytes).pointee)
         self.flags = self.bufferBytes[try advance()]
 
         guard self.role == FastCGI.Constants.FCGI_RESPONDER else {
@@ -204,7 +204,7 @@ class FastCGIRecordParser {
         let appStatusByte0 = self.bufferBytes[try advance()]
         let appStatusBytes : [UInt8] = [ appStatusByte3, appStatusByte2, appStatusByte1, appStatusByte0 ]
         
-        self.appStatus = FastCGIRecordParser.localByteOrderLarge(UnsafePointer<UInt32>(appStatusBytes).pointee)
+        self.appStatus = FastCGIRecordParser.getLocalByteOrderLarge(from: UnsafePointer<UInt32>(appStatusBytes).pointee)
     
     }
     
@@ -269,7 +269,7 @@ class FastCGIRecordParser {
             let lengthByteB0 : UInt8 = self.bufferBytes[try advance()]
             let lengthBytes : [UInt8] = [ lengthByteB3 & 0x7f, lengthByteB2, lengthByteB1, lengthByteB0 ]
 
-            return Int(FastCGIRecordParser.localByteOrderLarge(UnsafePointer<UInt32>(lengthBytes).pointee))
+            return Int(FastCGIRecordParser.getLocalByteOrderLarge(from: UnsafePointer<UInt32>(lengthBytes).pointee))
         }
         
     }

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -59,7 +59,7 @@ class FastCGIRecordParser {
     func advance() throws -> Int {
         
         guard self.pointer < self.buffer.length else {
-            throw FastCGI.RecordErrors.BufferExhausted
+            throw FastCGI.RecordErrors.bufferExhausted
         }
         
         let r = self.pointer
@@ -81,7 +81,7 @@ class FastCGIRecordParser {
         // because it means there aren't the bytes we expected
         //
         guard self.pointer <= self.buffer.length else {
-            throw FastCGI.RecordErrors.BufferExhausted
+            throw FastCGI.RecordErrors.bufferExhausted
         }
     }
     
@@ -123,7 +123,7 @@ class FastCGIRecordParser {
         self.version = self.bufferBytes[try advance()]
         
         guard self.version == FastCGI.Constants.FASTCGI_PROTOCOL_VERSION else {
-            throw FastCGI.RecordErrors.InvalidVersion
+            throw FastCGI.RecordErrors.invalidVersion
         }
     }
     
@@ -142,7 +142,7 @@ class FastCGIRecordParser {
             break
         
         default:
-            throw FastCGI.RecordErrors.InvalidType
+            throw FastCGI.RecordErrors.invalidType
         }
         
     }
@@ -189,7 +189,7 @@ class FastCGIRecordParser {
         self.flags = self.bufferBytes[try advance()]
 
         guard self.role == FastCGI.Constants.FCGI_RESPONDER else {
-            throw FastCGI.RecordErrors.UnsupportedRole
+            throw FastCGI.RecordErrors.unsupportedRole
         }
         
     }
@@ -296,7 +296,7 @@ class FastCGIRecordParser {
                 // this doesn't seem likely - web server sent an empty parameter
                 // name length, which is not allowed and has no point. error state.
                 //
-                throw FastCGI.RecordErrors.EmptyParams
+                throw FastCGI.RecordErrors.emptyParams
             }
             
             let currentPointer : Int = pointer
@@ -307,7 +307,7 @@ class FastCGIRecordParser {
                 // the data received from the web server couldn't be transcoded
                 // to a UTF8 string. This is an error.
                 //
-                throw FastCGI.RecordErrors.EmptyParams
+                throw FastCGI.RecordErrors.emptyParams
             }
             
             guard nameString.characters.count > 0 else {
@@ -315,7 +315,7 @@ class FastCGIRecordParser {
                 // but someone resulted in a string of zero length. 
                 // Strange, but an error none the less.
                 //
-                throw FastCGI.RecordErrors.EmptyParams
+                throw FastCGI.RecordErrors.emptyParams
             }
             
             // capture the parameter value
@@ -330,7 +330,7 @@ class FastCGIRecordParser {
                     // a value was supposed to have been provided but decoding it
                     // from the data failed.
                     //
-                    throw FastCGI.RecordErrors.EmptyParams
+                    throw FastCGI.RecordErrors.emptyParams
                 }
                 
                 // Done - store our paramter with the decoded value.

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -133,30 +133,15 @@ class FastCGIRecordParser {
         
         self.type = self.bufferBytes[try advance()]
         
-        var typeOk : Bool = false
+        switch self.type {
+        case FastCGI.Constants.FCGI_BEGIN_REQUEST,
+             FastCGI.Constants.FCGI_END_REQUEST,
+             FastCGI.Constants.FCGI_PARAMS,
+             FastCGI.Constants.FCGI_STDIN,
+             FastCGI.Constants.FCGI_STDOUT:
+            break
         
-        switch (self.type) {
-        case FastCGI.Constants.FCGI_BEGIN_REQUEST:
-            typeOk = true
-            break
-        case FastCGI.Constants.FCGI_END_REQUEST:
-            typeOk = true
-            break
-        case FastCGI.Constants.FCGI_PARAMS:
-            typeOk = true
-            break
-        case FastCGI.Constants.FCGI_STDIN:
-            typeOk = true
-            break
-        case FastCGI.Constants.FCGI_STDOUT:
-            typeOk = true
-            break
         default:
-            typeOk = false
-            break
-        }
-        
-        guard typeOk else {
             throw FastCGI.RecordErrors.InvalidType
         }
         

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -276,7 +276,7 @@ class FastCGIRecordParser {
     
     // Parse a parameter block
     //
-    private func parseParams() throws {
+    private func parseParameters() throws {
         
         guard self.contentLength > 0 else {
             return
@@ -296,7 +296,7 @@ class FastCGIRecordParser {
                 // this doesn't seem likely - web server sent an empty parameter
                 // name length, which is not allowed and has no point. error state.
                 //
-                throw FastCGI.RecordErrors.emptyParams
+                throw FastCGI.RecordErrors.emptyParameters
             }
             
             let currentPointer : Int = pointer
@@ -307,7 +307,7 @@ class FastCGIRecordParser {
                 // the data received from the web server couldn't be transcoded
                 // to a UTF8 string. This is an error.
                 //
-                throw FastCGI.RecordErrors.emptyParams
+                throw FastCGI.RecordErrors.emptyParameters
             }
             
             guard nameString.characters.count > 0 else {
@@ -315,7 +315,7 @@ class FastCGIRecordParser {
                 // but someone resulted in a string of zero length. 
                 // Strange, but an error none the less.
                 //
-                throw FastCGI.RecordErrors.emptyParams
+                throw FastCGI.RecordErrors.emptyParameters
             }
             
             // capture the parameter value
@@ -330,7 +330,7 @@ class FastCGIRecordParser {
                     // a value was supposed to have been provided but decoding it
                     // from the data failed.
                     //
-                    throw FastCGI.RecordErrors.emptyParams
+                    throw FastCGI.RecordErrors.emptyParameters
                 }
                 
                 // Done - store our paramter with the decoded value.
@@ -400,7 +400,7 @@ class FastCGIRecordParser {
             break
             
         case FastCGI.Constants.FCGI_PARAMS:
-            try parseParams()
+            try parseParameters()
             break
             
         default:

--- a/Sources/KituraNet/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGIServer.swift
@@ -1,0 +1,211 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import KituraSys
+import Socket
+import LoggerAPI
+
+public class FastCGIServer {
+ 
+    ///
+    /// Queue for listening and establishing new connections
+    ///
+    private static var listenerQueue = Queue(type: .parallel, label: "FastCGIServer.listenerQueue")
+
+    ///
+    /// Queue for handling client requests
+    ///
+    private static var clientHandlerQueue = Queue(type: .parallel, label: "FastCGIServer.clientHandlerQueue")
+
+    ///
+    /// ServerDelegate
+    ///
+    public weak var delegate: ServerDelegate?
+
+    ///
+    /// Port number for listening for new connections
+    ///
+    public private(set) var port: Int?
+    
+    ///
+    /// TCP socket used for listening for new connections
+    ///
+    private var listenSocket: Socket?
+
+    ///
+    /// Whether the FastCGI server has stopped listening
+    ///
+    var stopped = false
+
+    ///
+    /// Listens for connections on a socket
+    ///
+    /// - Parameter port: port number for new connections (ex. 9000)
+    ///
+    public func listen(port: Int) {
+        
+        self.port = port
+        
+        do {
+            
+            self.listenSocket = try Socket.create()
+            
+        } catch let error as Socket.Error {
+            print("FastCGI error reported:\n \(error.description)")
+        } catch {
+            print("Unexpected FastCGI error...")
+        }
+        
+        let queuedBlock = {
+            self.listen(socket: self.listenSocket, port: self.port!)
+        }
+        
+        ListenerGroup.enqueueAsynchronously(on: FastCGIServer.listenerQueue, block: queuedBlock)
+        
+    }
+    
+    ///
+    /// Static method to create a new FastCGIServer and have it listen for conenctions
+    ///
+    /// - Parameter port: port number for accepting new connections
+    /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
+    ///
+    /// - Returns: a new FastCGIServer instance
+    ///
+    public static func listen(port: Int, delegate: ServerDelegate) -> FastCGIServer {
+        
+        let server = FastCGI.createServer()
+        server.delegate = delegate
+        server.listen(port: port)
+        return server
+        
+    }
+    
+    //
+    // Retrieve an appropriate connection backlog value for our listen socket.
+    // This log is taken from Nginx, and tests out with good results.
+    //
+    private static func getConnectionBacklog() -> Int {
+        #if os(Linux)
+            return 511;
+        #else
+            return -1
+        #endif
+    }
+    
+    ///
+    /// Handles instructions for listening on a socket
+    ///
+    /// - Parameter socket: socket to use for connecting
+    /// - Parameter port: number to listen on
+    ///
+    func listen(socket: Socket?, port: Int) {
+        
+        do {
+            guard let socket = socket else {
+                return
+            }
+            
+            try socket.listen(on: port, maxPendingConnections:FastCGIServer.getConnectionBacklog())
+            Log.info("Listening on port \(port) (FastCGI)")
+            
+            // TODO: Change server exit to not rely on error being thrown
+            repeat {
+                let clientSocket = try socket.acceptClientConnection()
+                Log.info("Accepted FastCGI connection from: " +
+                    "\(clientSocket.remoteHostname):\(clientSocket.remotePort)")
+                handleClientRequest(socket: clientSocket)
+            } while true
+        } catch let error as Socket.Error {
+            
+            if stopped && error.errorCode == Int32(Socket.SOCKET_ERR_ACCEPT_FAILED) {
+                Log.info("FastCGI Server has stopped listening")
+            }
+            else {
+                Log.error("FastCGI Error reported:\n \(error.description)")
+            }
+        } catch {
+            Log.error("Unexpected FastCGI error...")
+        }
+    }
+    
+    ///
+    /// Send multiplex request rejections
+    //
+    func sendMultiplexRequestRejections(request: FastCGIServerRequest, response: FastCGIServerResponse) {
+        if (request.extraRequestIds.count > 0) {
+            for requestId in request.extraRequestIds {
+                do {
+                    try response.rejectMultiplexConnecton(requestId: requestId)
+                } catch {}
+            }
+        }
+    }
+    
+    ///
+    /// Handle a new client FastCGI request
+    ///
+    /// - Parameter clientSocket: the socket used for connecting
+    ///
+    func handleClientRequest(socket clientSocket: Socket) {
+        
+        guard let delegate = delegate else {
+            return
+        }
+        
+        FastCGIServer.clientHandlerQueue.enqueueAsynchronously() {
+            
+            let request = FastCGIServerRequest(socket: clientSocket)
+            let response = FastCGIServerResponse(socket: clientSocket, request: request)
+            
+            request.parse() { status in
+                switch status {
+                case .success:
+                    self.sendMultiplexRequestRejections(request: request, response: response)
+                    delegate.handle(request: request, response: response)
+                    break;
+                case .unsupportedRole:
+                    // response.unsupportedRole() - not thrown
+                    do {
+                        try response.rejectUnsupportedRole()
+                    } catch {}
+                    clientSocket.close()
+                    break;
+                default:
+                    // we just want to ignore every other status for now
+                    // as they all result in simply closing the conncetion anyways.
+                    clientSocket.close()
+                    break;
+                }
+            }
+            
+        }
+    }
+    
+    ///
+    /// Stop listening for new connections
+    ///
+    public func stop() {
+        
+        if let listenSocket = listenSocket {
+            stopped = true
+            listenSocket.close()
+        }
+        
+    }
+
+    
+}

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -1,0 +1,482 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import KituraSys
+import Socket
+
+public class FastCGIServerRequest : ServerRequest {
+    
+    ///
+    /// Socket for the request
+    ///
+    private let socket: Socket
+    
+    ///
+    /// server IP address pulled from socket
+    ///
+    public private(set) var remoteAddress: String = ""
+
+    ///
+    /// Major version for HTTP
+    ///
+    public private(set) var httpVersionMajor: UInt16? = 1
+    
+    ///
+    /// Minor version for HTTP
+    ///
+    public private(set) var httpVersionMinor: UInt16? = 1
+    
+    ///
+    /// Set of headers
+    ///
+    public var headers = HeadersContainer()
+    
+    ///
+    /// HTTP Method
+    ///
+    public private(set) var method: String = ""
+    
+    ///
+    /// URL strings.
+    ///
+    public var urlString : String {
+        guard self.url.length > 0 else {
+            return ""
+        }
+        return StringUtils.fromUtf8String(self.url)!
+    }
+    
+    ///
+    /// URL Components received from FastCGI
+    ///
+    private var requestScheme : String? = nil
+    private var requestHost : String? = nil
+    private var requestServerAddress : String? = nil
+    private var requestServerName : String? = nil
+    private var requestPort : String? = nil
+    private var requestUri : String? = nil
+    
+    ///
+    /// Raw URL
+    ///
+    public private(set) var url = NSMutableData()
+
+    ///
+    /// Chunk of body read in by the http_parser, filled by callbacks to onBody
+    ///
+    private var bodyChunk = BufferList()
+
+    ///
+    /// State of incoming message handling
+    ///
+    private var status = Status.initial
+    
+    ///
+    /// The request ID established by the FastCGI client
+    /// We also store an array of request ID's that are not our primary
+    /// one. When the main request is done, the FastCGIServer can reject the
+    /// extra requests as being unusable.
+    ///
+    public private(set) var requestId : UInt16 = 0
+    public private(set) var extraRequestIds : [UInt16] = []
+    
+    ///
+    /// Some defaults
+    ///
+    private static let defaultProtocolScheme : String = "http"
+    private static let quietPorts : [String] = ["80", "443"]
+    private static let defaultMethod : String = "GET"
+    private static let defaultAddress : String = "127.0.0.1"
+    private static let defaultUri : String = "/"
+    
+    ///
+    /// List of status states
+    ///
+    private enum Status {
+        case initial
+        case requestStarted
+        case headersComplete
+        case requestComplete
+    }
+    
+    ///
+    /// HTTP parser error types
+    ///
+    public enum FastCGIParserErrorType {
+        case success
+        case protocolError
+        case invalidType
+        case clientDisconnect
+        case unsupportedRole
+        case internalError
+    }
+    
+    ///
+    /// Constructor
+    ///
+    required public init (socket: Socket) {
+        self.socket = socket
+    }
+    
+    // 
+    // Read data received (perhaps from POST) into an NSData object
+    //
+    public func read(into data: NSMutableData) throws -> Int {
+        return self.bodyChunk.fill(data: data)
+    }
+    
+    //
+    // Read all data into the object.
+    //
+    public func readAllData(into data: NSMutableData) throws -> Int {
+        return self.bodyChunk.fill(data: data)
+    }
+    
+    //
+    // Read data received (perhaps from POST) as a string
+    //
+    public func readString() throws -> String? {
+        let data : NSMutableData = NSMutableData()
+        let bytes : Int = self.bodyChunk.fill(data: data)
+        
+        if (bytes>0) {
+            return StringUtils.fromUtf8String(data)
+        } else {
+            return ""
+        }
+    }
+    
+    func postProcessUrlParameter() -> Void {
+        
+        // reset the current url
+        self.url.length = 0
+        
+        // set our protocol scheme
+        if (self.requestScheme?.characters.count > 0) {
+            self.url.append(StringUtils.toUtf8String(self.requestScheme!)!)
+        } else {
+            self.url.append(StringUtils.toUtf8String(FastCGIServerRequest.defaultProtocolScheme)!)
+        }
+
+        self.url.append(StringUtils.toUtf8String("://")!)
+        
+        // set our host name
+        if (self.requestHost?.characters.count > 0) {
+            self.url.append(StringUtils.toUtf8String(self.requestHost!)!)
+        } else if (self.requestServerName?.characters.count > 0) {
+            self.url.append(StringUtils.toUtf8String(self.requestServerName!)!)
+        } else if (self.requestServerAddress?.characters.count > 0) {
+            self.url.append(StringUtils.toUtf8String(self.requestServerAddress!)!)
+        } else {
+            self.url.append(StringUtils.toUtf8String(FastCGIServerRequest.defaultAddress)!)
+        }
+        
+        // set the port
+        if (self.requestPort?.characters.count > 0) {
+            if (!FastCGIServerRequest.quietPorts.contains(self.requestPort!)) {
+                self.url.append(StringUtils.toUtf8String(":")!)
+                self.url.append(StringUtils.toUtf8String(self.requestPort!)!)
+            }
+        }
+        
+        // set the uri
+        if (self.requestUri?.characters.count > 0) {
+            self.url.append(StringUtils.toUtf8String(self.requestUri!)!)
+        }
+                
+    }
+    
+    //
+    // We've received all the parameters the server is going to send us, 
+    // so lets massage these into place and make sure, at worst, sane 
+    // defaults are in place.
+    //
+    private func postProcessParameters() {
+        
+        // make sure our method is set
+        if (self.method.characters.count == 0) {
+            self.method = FastCGIServerRequest.defaultMethod
+        }
+        
+        // make sure our remoteAddress is set
+        if (self.remoteAddress.characters.count == 0) {
+            self.remoteAddress = self.socket.remoteHostname
+        }
+        
+        // complete our URL string
+        self.postProcessUrlParameter()
+        
+        // make sure our protocol is configured
+        
+    }
+    
+    //
+    // FastCGI delivers headers that were originally sent by the browser/client
+    // with "HTTP_" prefixed.
+    //
+    private func processHttpHeader(_ name: String, value: String, remove: String) {
+        
+        var processedName : String = name.substring(from:
+            name.index(name.startIndex, offsetBy: remove.characters.count))
+        
+        processedName = processedName.replacingOccurrences(of: "_", with: "-")
+        processedName = processedName.capitalized
+        
+        self.headers.append(processedName as String, value: value)
+    }
+    
+    //
+    // Parse the server protocol into a major and minor version
+    //
+    private func processServerProtocol(_ protocolString: String) {
+        
+        guard protocolString.lowercased().hasPrefix("http/") &&
+            protocolString.characters.count > "http/".characters.count else {
+            return;
+        }
+        
+        let versionPortion : String = protocolString.substring(from:
+            protocolString.index(protocolString.startIndex, offsetBy: "http/".characters.count))
+        var decimalPosition : Int = 0
+        
+        for i in versionPortion.characters {
+            if i == "." {
+                break;
+            } else {
+                decimalPosition = decimalPosition + 1
+            }
+        }
+        
+        var majorVersion : UInt16? = nil
+        var minorVersion : UInt16? = nil
+        
+        // get major version
+        if (decimalPosition > 0) {
+            let majorPortion : String = versionPortion.substring(to:
+                versionPortion.index(versionPortion.startIndex, offsetBy: decimalPosition))
+            majorVersion = UInt16(majorPortion)
+        }
+        
+        // get minor version
+        if (protocolString.characters.count > decimalPosition) {
+            let minorPortion : String = versionPortion.substring(from:
+                versionPortion.index(versionPortion.startIndex, offsetBy: decimalPosition + 1))
+            minorVersion = UInt16(minorPortion)
+        }
+        
+        // assign our values if applicable
+        if (majorVersion != nil && minorVersion != nil) {
+            self.httpVersionMajor = majorVersion!
+            self.httpVersionMinor = minorVersion!
+        }
+    
+    }
+    
+    
+    // process our headers.
+    // there are some special case headers we want to deal with directly.
+    // for the rest else, we want to add HTTP_ headers to the header table
+    // after formatting to Web style (remove HTTP_, case and dash fixing, etc).
+    // everything else we just discard.
+    //
+    private func processHeader (_ name : String, value: String) {
+        
+        if (name.caseInsensitiveCompare("REQUEST_METHOD") == .orderedSame) {
+            self.method = value
+        } else if (name.caseInsensitiveCompare("REQUEST_SCHEME") == .orderedSame) {
+            self.requestScheme = value
+        } else if (name.caseInsensitiveCompare("HTTP_HOST") == .orderedSame) {
+            self.requestHost = value
+            self.processHttpHeader(name, value: value, remove: "HTTP_")
+        } else if (name.caseInsensitiveCompare("SERVER_ADDR") == .orderedSame) {
+            self.requestServerAddress = value
+        } else if (name.caseInsensitiveCompare("SERVER_NAME") == .orderedSame) {
+            self.requestServerName = value
+        } else if (name.caseInsensitiveCompare("SERVER_PORT") == .orderedSame) {
+            self.requestPort = value
+        } else if (name.caseInsensitiveCompare("REQUEST_URI") == .orderedSame) {
+            self.requestUri = value
+        } else if (name.caseInsensitiveCompare("REMOTE_ADDR") == .orderedSame) {
+            self.remoteAddress = value
+        } else if (name.caseInsensitiveCompare("SERVER_PROTOCOL") == .orderedSame) {
+            self.processServerProtocol(value)
+        }
+        else if (name.hasPrefix("HTTP_")) {
+            // this is where we process
+            self.processHttpHeader(name, value: value, remove: "HTTP_")
+            return;
+        }
+
+        // send all headers with FASTCGI_ prefixed.
+        // this way we can see what's going on with them.
+        // commented out for now pending community discussion as to best approach here
+        
+        /* self.headers.append("FASTCGI_".appending(name), value: value) */
+        
+    }
+    
+    // process a record parsed from the connection.
+    // this has already been parsed and is just waiting for us to make a decision.
+    //
+    private func processRecord (_ record : FastCGIRecordParser) throws {
+        
+        // is this record for a request that is an extra
+        // request that we've already seen? if so, ignore it.
+        //
+        guard !self.extraRequestIds.contains(record.requestId) else {
+            return;
+        }
+
+        if (self.status == Status.initial && record.type == FastCGI.Constants.FCGI_BEGIN_REQUEST) {
+            self.requestId = record.requestId
+            self.status = Status.requestStarted
+        }
+        else if (record.type == FastCGI.Constants.FCGI_BEGIN_REQUEST) {
+            self.extraRequestIds.append(record.requestId)
+        }
+        else if (self.status == Status.requestStarted && record.type == FastCGI.Constants.FCGI_PARAMS) {
+            
+            // this request and the request in the record have to match
+            // if not, something utterly insane has happened (params without begin)
+            // we want to keep processing the real request though, so we just ignore this
+            guard record.requestId == self.requestId else {
+                return;
+            }
+            
+            if (record.headers.count > 0) {
+                for pair in record.headers  {
+                    // right here we can send to a proper processor
+                    // this is where actual real transposition will happen 
+                    // adn we can remove requestComplete() from the parse loop
+                    self.processHeader(pair["name"]!, value: pair["value"]!)
+                }
+            } else {
+                // no params were received in this parameter block.
+                // which means parameters are completed.
+                self.postProcessParameters()
+                self.status = Status.headersComplete
+            }
+            
+        }
+        else if (self.status == Status.headersComplete && record.type == FastCGI.Constants.FCGI_STDIN) {
+            
+            // this request and the request in the record have to match
+            // if not, something utterly insane has happened (params without begin)
+            // we want to keep processing the real request though, so we just ignore this
+            guard record.requestId == self.requestId else {
+                return;
+            }
+            
+            if (record.data!.length > 0) {
+                // we've received some body data
+                self.bodyChunk.append(data: record.data!)
+            }
+            else {
+                // zero lenght stdin means request is done
+                self.status = Status.requestComplete
+            }
+            
+        }
+        
+    }
+    
+    //
+    // Parse the request from FastCGI.
+    //
+    func parse (_ callback: (FastCGIParserErrorType) -> Void) {
+        
+        
+        let networkBuffer : NSMutableData = NSMutableData()
+        
+        // we want to repeat this until we're done
+        // in case the intaken data isn't sufficient to 
+        // parse completed records.
+        //
+        repeat {
+            
+            do {
+                let socketBuffer : NSMutableData = NSMutableData()
+                let bytesRead = try socket.read(into: socketBuffer)
+                
+                guard bytesRead > 0 else {
+                    // did our client disconnect? strange.
+                    callback(.clientDisconnect)
+                    return
+                }
+                
+                // add the read data to our main buffer
+                networkBuffer.append(socketBuffer)
+                
+                // we want to parse records out one at a time.
+                repeat {
+                    // make a parser
+                    let parser = FastCGIRecordParser(networkBuffer)
+                    
+                    // replace our network buffer of read data with the 
+                    // data sent back from the parser (data left over once the 
+                    // record at the head of the array was parsed
+                    // 
+                    // Note that if we get an error indicating that the buffer 
+                    // suffered an exhaustion, we want to read more data from 
+                    // the socket as it's likely that we don't have sufficient
+                    // data yet.
+                    //
+                    do {
+                        let remainingData : NSData = try parser.parse()
+                        networkBuffer.setData(remainingData)
+                    }
+                    catch (FastCGI.RecordErrors.BufferExhausted) {
+                        // break out of this repeat, which will loop
+                        // this means there was insufficient data to parse
+                        // a single record.
+                        break;
+                    }
+                    
+                    // if we got here, we parsed a record.
+                    try self.processRecord(parser)
+                    
+                    // if we're ready to send back a response, go ahead and do so
+                    if (self.status == Status.requestComplete) {
+                        callback(.success)
+                        return;
+                    }
+                    
+                }
+                while true
+                
+                
+            } catch (FastCGI.RecordErrors.InvalidVersion) {
+                callback(.protocolError)
+                return
+            } catch (FastCGI.RecordErrors.EmptyParams) {
+                callback(.protocolError)
+                return
+            } catch (FastCGI.RecordErrors.InvalidType) {
+                callback(.invalidType)
+                return;
+            } catch (FastCGI.RecordErrors.UnsupportedRole) {
+                callback(.unsupportedRole)
+                return;
+            } catch {
+                callback(.internalError)
+                return;
+            }
+            
+        } while true
+        
+    }
+}

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -300,7 +300,7 @@ public class FastCGIServerRequest : ServerRequest {
             if i == "." {
                 break
             } else {
-                decimalPosition = decimalPosition + 1
+                decimalPosition += 1
             }
         }
         

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -450,7 +450,7 @@ public class FastCGIServerRequest : ServerRequest {
             if record.requestId == self.requestId {
                 // a second begin request is insanity.
                 //
-                throw FastCGI.RecordErrors.ProtocolError
+                throw FastCGI.RecordErrors.protocolError
             } else {
                 // this is an attempt to multiplex the connection. remember this
                 // for later, as we can reject this safely with a response.
@@ -569,7 +569,7 @@ public class FastCGIServerRequest : ServerRequest {
                         let remainingData : NSData = try parser.parse()
                         networkBuffer.setData(remainingData)
                     }
-                    catch FastCGI.RecordErrors.BufferExhausted {
+                    catch FastCGI.RecordErrors.bufferExhausted {
                         // break out of this repeat, which will start the 
                         // outer repeat loop again (read more data from the
                         // socket).
@@ -593,19 +593,19 @@ public class FastCGIServerRequest : ServerRequest {
                 while true
                 
                 
-            } catch FastCGI.RecordErrors.InvalidVersion {
+            } catch FastCGI.RecordErrors.invalidVersion {
                 callback(.protocolError)
                 return
-            } catch FastCGI.RecordErrors.ProtocolError {
+            } catch FastCGI.RecordErrors.protocolError {
                 callback(.protocolError)
                 return
-            } catch FastCGI.RecordErrors.EmptyParams {
+            } catch FastCGI.RecordErrors.emptyParams {
                 callback(.protocolError)
                 return
-            } catch FastCGI.RecordErrors.InvalidType {
+            } catch FastCGI.RecordErrors.invalidType {
                 callback(.invalidType)
                 return
-            } catch FastCGI.RecordErrors.UnsupportedRole {
+            } catch FastCGI.RecordErrors.unsupportedRole {
                 callback(.unsupportedRole)
                 return
             } catch {

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -599,7 +599,7 @@ public class FastCGIServerRequest : ServerRequest {
             } catch FastCGI.RecordErrors.protocolError {
                 callback(.protocolError)
                 return
-            } catch FastCGI.RecordErrors.emptyParams {
+            } catch FastCGI.RecordErrors.emptyParameters {
                 callback(.protocolError)
                 return
             } catch FastCGI.RecordErrors.invalidType {

--- a/Sources/KituraNet/FastCGIServerResponse.swift
+++ b/Sources/KituraNet/FastCGIServerResponse.swift
@@ -173,7 +173,7 @@ public class FastCGIServerResponse : ServerResponse {
     private func getRequestCompleteMessage() throws -> NSData {
         
         guard let serverRequest = self.serverRequest else {
-            throw FastCGI.RecordErrors.InternalError
+            throw FastCGI.RecordErrors.internalError
         }
         
         return try self.getEndRequestMessage(requestId: serverRequest.requestId,
@@ -197,13 +197,13 @@ public class FastCGIServerResponse : ServerResponse {
     private func getUnsupportedRoleMessage() throws -> NSData? {
         
         guard let serverRequest = self.serverRequest else {
-            throw FastCGI.RecordErrors.InternalError
+            throw FastCGI.RecordErrors.internalError
         }
         guard let requestId : UInt16 = serverRequest.requestId else {
-            throw FastCGI.RecordErrors.InternalError
+            throw FastCGI.RecordErrors.internalError
         }
         guard requestId != FastCGI.Constants.FASTCGI_DEFAULT_REQUEST_ID else {
-            throw FastCGI.RecordErrors.InternalError
+            throw FastCGI.RecordErrors.internalError
         }
         
         return try self.getEndRequestMessage(requestId: requestId, protocolStatus: FastCGI.Constants.FCGI_UNKNOWN_ROLE)

--- a/Sources/KituraNet/FastCGIServerResponse.swift
+++ b/Sources/KituraNet/FastCGIServerResponse.swift
@@ -1,0 +1,286 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import Socket
+import KituraSys
+
+public class FastCGIServerResponse : ServerResponse {
+ 
+    ///
+    /// Socket for the ServerResponse
+    ///
+    private var socket: Socket?
+
+    ///
+    /// Size of buffers (64 * 1024 is the max size for a FastCGI outbound record)
+    /// Which also gives a bit more internal buffer room.
+    ///
+    private static let bufferSize = 64 * 1024
+    
+    ///
+    /// Buffer for HTTP response line, headers, and short bodies
+    ///
+    private var buffer: NSMutableData!
+
+    ///
+    /// Whether or not the HTTP response line and headers have been flushed.
+    ///
+    private var startFlushed = false
+
+    ///
+    /// TODO: ???
+    ///
+    public var headers = HeadersContainer()
+    
+    ///
+    /// Status code
+    ///
+    private var status = HTTPStatusCode.OK.rawValue
+    
+    ///
+    /// Corresponding server request
+    ///
+    private weak var serverRequest : FastCGIServerRequest?
+    
+    ///
+    /// Status code
+    ///
+    public var statusCode: HTTPStatusCode? {
+        get {
+            return HTTPStatusCode(rawValue: status)
+        }
+        set (newValue) {
+            if let newValue = newValue where !startFlushed {
+                status = newValue.rawValue
+            }
+        }
+    }
+    
+    ///
+    /// Initializes a ServerResponse instance
+    ///
+    init(socket: Socket, request: FastCGIServerRequest) {
+        self.socket = socket
+        self.serverRequest = request
+        self.buffer = NSMutableData(capacity: FastCGIServerResponse.bufferSize)!
+        headers["Date"] = [SPIUtils.httpDate()]
+    }
+    
+    
+    // 
+    // The following write and end methods are basically convenience methods
+    // They rely on other methods to do their work.
+    //
+    public func end(text: String) throws {
+        try self.write(from: text)
+        try end()
+    }
+
+    public func write(from string: String) throws {
+        try self.write(from: StringUtils.toUtf8String(string)!)
+    }
+    
+    //
+    // Actual write methods
+    //
+    public func write(from data: NSData) throws {
+        
+        try startResponse()
+        
+        if (self.buffer.length + data.length > FastCGIServerResponse.bufferSize) {
+            try flush()
+        }
+        
+        self.buffer.append(data)
+    }
+    
+    public func end() throws {
+        try startResponse()
+        try concludeResponse()
+    }
+    
+    ///
+    /// Begin the buffer flush.
+    ///
+    /// This can only happen once and is called by all the tools that write
+    /// data to the socket (from the implementation side). Effectively, this
+    /// always happens before a buffer flush to make sure headers are written.
+    ///
+    /// Note that we can jump the queue internally to bypass this for writing
+    /// FastCGI error messages.
+    ///
+    private func startResponse() throws {
+        
+        guard socket != nil && !startFlushed else {
+            return
+        }
+
+        var headerData = ""
+
+        // add our status header for FastCGI
+        headerData.append("Status: \(self.status) \(HTTP.statusCodes[self.status]!)\r\n")
+
+        // add the rest of our response headers
+        for (key, valueSet) in headers.headers {
+            for value in valueSet {
+                headerData.append(key)
+                headerData.append(": ")
+                headerData.append(value)
+                headerData.append("\r\n")
+            }
+        }
+
+        headerData.append("\r\n")
+        
+        try writeToSocket(StringUtils.toUtf8String(headerData)!)
+        try flush()
+        
+        startFlushed = true
+    }
+    
+    /// 
+    /// Get messages for FastCGI.
+    ///
+    private func getEndRequestMessage(requestId: UInt16, protocolStatus: UInt8) throws -> NSData {
+        
+        let record = FastCGIRecordCreate()
+        
+        record.recordType = FastCGI.Constants.FCGI_END_REQUEST
+        record.protocolStatus = protocolStatus
+        record.requestId = requestId
+        
+        return try record.create()
+        
+    }
+    
+    private func getRequestCompleteMessage() throws -> NSData {
+        return try self.getEndRequestMessage(requestId: self.serverRequest!.requestId,
+                                             protocolStatus: FastCGI.Constants.FCGI_REQUEST_COMPLETE)
+    }
+
+    private func getNoMultiplexingMessage(requestId: UInt16) throws -> NSData {
+        return try self.getEndRequestMessage(requestId: requestId, protocolStatus: FastCGI.Constants.FCGI_CANT_MPX_CONN)
+    }
+
+    private func getUnsupportedRoleMessage() throws -> NSData? {
+        
+        guard self.serverRequest?.requestId != nil &&
+            self.serverRequest?.requestId != FastCGI.Constants.FASTCGI_DEFAULT_REQUEST_ID else {
+                return nil
+        }
+        
+        return try self.getEndRequestMessage(requestId: self.serverRequest!.requestId,
+                                             protocolStatus: FastCGI.Constants.FCGI_UNKNOWN_ROLE)
+    }
+
+    ///
+    /// External message write for multiplex rejection    
+    ///
+    public func rejectMultiplexConnecton(requestId: UInt16) throws {
+        let message : NSData = try self.getNoMultiplexingMessage(requestId: requestId)
+        try self.writeToSocket(message, wrapAsMessage: false)
+    }
+    
+    /// 
+    /// External message write for role rejection
+    ///
+    public func rejectUnsupportedRole() throws {
+        guard let message : NSData = try self.getUnsupportedRoleMessage() else {
+            return
+        }
+        try self.writeToSocket(message, wrapAsMessage: false)
+    }
+    
+    ///
+    /// Get a FastCGI STDOUT message, wrapping the specified data
+    /// for delivery.
+    ///
+    private func getMessage(buffer: NSData?) throws -> NSData {
+        
+        let record = FastCGIRecordCreate()
+        
+        record.recordType = FastCGI.Constants.FCGI_STDOUT
+        record.requestId = self.serverRequest!.requestId
+        
+        if (buffer != nil) {
+            record.data = buffer
+        }
+        
+        return try record.create()
+                
+    }
+    
+    ///
+    /// Write NSData to the socket
+    ///
+    private func writeToSocket(_ data: NSData, wrapAsMessage: Bool = true) throws {
+
+        guard let socket = socket else {
+            return
+        }
+
+        if (wrapAsMessage) {
+            try socket.write(from: getMessage(buffer: data))
+        } else {
+            try socket.write(from: data)
+        }
+        
+    }
+    
+    ///
+    /// Flush any data in the buffer to the socket, then
+    /// reest the buffer for more data.
+    ///
+    private func flush() throws {
+        
+        guard self.buffer.length > 0 else {
+            return;
+        }
+    
+        try self.writeToSocket(self.buffer)
+        self.buffer.length = 0
+        
+    }
+    
+    ///
+    /// Conclude our standard response
+    /// We're basically sending out anything left in the buffer, followed by a blank
+    /// STDOUT message, followed by a complete message.
+    ///
+    /// Note that unlike the HTTP implementation, we aren't closing the connection
+    /// here because we may want to send other messages after the fact (multiplex denials)
+    ///
+    private func concludeResponse() throws {    
+        
+        // flush the reset of the buffer
+        try self.flush()
+        
+        // send a blank packet
+        try self.writeToSocket(getMessage(buffer: nil), wrapAsMessage: false)
+        
+        // send done
+        try self.writeToSocket(getRequestCompleteMessage(), wrapAsMessage: false)
+        
+        // close the socket.
+        // we presently don't support keep-alive so this is fine.
+        if let socket = self.socket {
+            socket.close()
+        }
+        self.socket = nil
+    }
+
+}

--- a/Sources/KituraNet/HTTPServer.swift
+++ b/Sources/KituraNet/HTTPServer.swift
@@ -23,11 +23,6 @@ import Socket
 public class HTTPServer {
 
     ///
-    /// Group for waiting on listeners
-    ///
-    private static let listenerGroup = Group()
-
-    ///
     /// Queue for listening and establishing new connections
     ///
     private static var listenerQueue = Queue(type: .parallel, label: "HTTPServer.listenerQueue")
@@ -81,32 +76,14 @@ public class HTTPServer {
 			self.listen(socket: self.listenSocket, port: self.port!)
 		}
 		
-        /** Old code that used the main queue
-		if notOnMainQueue {
-			HTTPServer.listenerQueue.enqueueAsynchronously(queuedBlock)
-		}
-		else {
-			Queue.enqueueIfFirstOnMain(queue: HTTPServer.listenerQueue, block: queuedBlock)
-		}
-        **/
-        
-        HTTPServer.listenerGroup.enqueueAsynchronously(on: HTTPServer.listenerQueue, block: queuedBlock)
+        ListenerGroup.enqueueAsynchronously(on: HTTPServer.listenerQueue, block: queuedBlock)
         
     }
-    
-    ///
-    /// Wait for all of the listeners to stop
-    ///
-    public static func waitForListeners() {
-        listenerGroup.wait(for: .ever)
-    }
-
 
     ///
     /// Stop listening for new connections
     ///
     public func stop() {
-        
         if let listenSocket = listenSocket {
             stopped = true
             listenSocket.close()
@@ -203,5 +180,16 @@ public class HTTPServer {
             }
 
         }
+    }
+    
+    ///
+    /// Wait for all of the listeners to stop
+    ///
+    /// TODO: Note that this calls the ListenerGroup object, and is left in for
+    /// backwards compability reasons. Can be safely removed once IBM-Swift/Kitura/Kitura.swift 
+    /// is patched to directly talk to ListenerGroup.
+    ///
+    public static func waitForListeners() {
+        ListenerGroup.waitForListeners()
     }
 }

--- a/Sources/KituraNet/ListenerGroup.swift
+++ b/Sources/KituraNet/ListenerGroup.swift
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import KituraSys
+import Socket
+import LoggerAPI
+
+public class ListenerGroup {
+    
+    ///
+    /// Group for waiting on listeners
+    ///
+    private static let group = Group()
+
+    ///
+    /// Wait for all of the listeners to stop
+    ///
+    public static func waitForListeners() {
+        group.wait(for: .ever)
+    }
+    
+    //
+    // Enqueue a block of code on a given queue, assigning
+    // it to the listener group int the process (so we can wait
+    // on it later).
+    //
+    public static func enqueueAsynchronously(on queue: Queue, block: () -> Void) {
+        ListenerGroup.group.enqueueAsynchronously(on: queue, block: block)
+    }
+    
+}

--- a/Tests/KituraNet/FastCGIProtocolTests.swift
+++ b/Tests/KituraNet/FastCGIProtocolTests.swift
@@ -131,7 +131,7 @@ class FastCGIProtocolTests: XCTestCase {
             XCTFail("Creator allowed the creation of an enormous payload (>64k)")
             
         }
-        catch FastCGI.RecordErrors.OversizeData {
+        catch FastCGI.RecordErrors.oversizeData {
             // this is fine - is expected.
         }
         catch {
@@ -208,7 +208,7 @@ class FastCGIProtocolTests: XCTestCase {
             
             XCTFail("Record creator allowed record with no record ID to be created.")
         }
-        catch FastCGI.RecordErrors.InvalidRequestId {
+        catch FastCGI.RecordErrors.invalidRequestId {
             // ignore this - expected behaviour
         }
         catch {
@@ -231,7 +231,7 @@ class FastCGIProtocolTests: XCTestCase {
             
             XCTFail("Record creator allowed strange record to be created.")
         }
-        catch FastCGI.RecordErrors.InvalidType {
+        catch FastCGI.RecordErrors.invalidType {
             // ignore this - expected behaviour
         }
         catch {

--- a/Tests/KituraNet/FastCGIProtocolTests.swift
+++ b/Tests/KituraNet/FastCGIProtocolTests.swift
@@ -295,20 +295,20 @@ class FastCGIProtocolTests: XCTestCase {
             }
             
             // create some parameters to tests
-            var params : [(String,String)] = []
+            var parameters : [(String,String)] = []
             
-            params.append(("SHORT_KEY_A", "SHORT_VALUE"))
-            params.append(("SHORT_KEY_B", "LONG_VALUE_" + longString))
-            params.append(("LONG_KEY_A_" + longString, "SHORT_VALUE"))
-            params.append(("LONG_KEY_A_" + longString, "LONG_VALUE_" + longString))
+            parameters.append(("SHORT_KEY_A", "SHORT_VALUE"))
+            parameters.append(("SHORT_KEY_B", "LONG_VALUE_" + longString))
+            parameters.append(("LONG_KEY_A_" + longString, "SHORT_VALUE"))
+            parameters.append(("LONG_KEY_A_" + longString, "LONG_VALUE_" + longString))
             
             // test sending those parameters
             let creator : FastCGIRecordCreate = FastCGIRecordCreate()
             creator.recordType = FastCGI.Constants.FCGI_PARAMS
             creator.requestId = 1
             
-            for currentHeader : (String,String) in params {
-                creator.params.append((currentHeader.0, currentHeader.1))
+            for currentHeader : (String,String) in parameters {
+                creator.parameters.append((currentHeader.0, currentHeader.1))
             }
             
             let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
@@ -319,7 +319,7 @@ class FastCGIProtocolTests: XCTestCase {
             XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
             
             // Check what we received was what we expected.
-            for sourceHeader : (String,String) in params {
+            for sourceHeader : (String,String) in parameters {
                 
                 var pairReceived : Bool = false
                 

--- a/Tests/KituraNet/FastCGIProtocolTests.swift
+++ b/Tests/KituraNet/FastCGIProtocolTests.swift
@@ -1,0 +1,349 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+@testable import KituraNet
+
+#if os(Linux)
+    import Foundation
+    import Glibc
+#else
+    import Darwin
+    import Foundation
+#endif
+
+//
+// Test that the FastCGI Record Creator and Parses classes work as expected.
+// This is technically not a pure test since we're not using a reference
+// implementation to generate the test packets but it does show that the parser and creator,
+// which don't share code other than constants and exceptions, can interoperate.
+//
+// It would be embarrasingly broken if they did not...
+//
+class FastCGIProtocolTests: XCTestCase {
+
+    // All tests
+    //
+    static var allTests : [(String, (FastCGIProtocolTests) -> () throws -> Void)] {
+        return [
+            ("testNoRequestId", testNoRequestId),
+            ("testBadRecordType", testBadRecordType),
+            ("testRequestBeginKeepalive", testRequestBeginKeepalive),
+            ("testRequestBeginNoKeepalive", testRequestBeginNoKeepalive),
+            ("testParameters", testParameters),
+            ("testDataOutput", testDataOutput),
+            ("testDataInput", testDataOutput),
+            ("testOversizeDataOutput", testOversizeDataOutput),
+            ("testOversizeDataInput", testOversizeDataInput),
+            ("testEndRequestSuccess", testEndRequestSuccess),
+            ("testEndRequestUnknownRole", testEndRequestUnknownRole),
+            ("testEndRequestCannotMultiplex", testEndRequestCannotMultiplex)
+        ]
+    }
+    
+    // Perform a request end test (FCGI_END_REQUEST) with a varying protocol status.
+    //
+    func executeRequestEnd(protocolStatus: UInt8) {
+        do {
+            let creator : FastCGIRecordCreate = FastCGIRecordCreate()
+            creator.recordType = FastCGI.Constants.FCGI_END_REQUEST
+            creator.requestId = 1
+            creator.protocolStatus = protocolStatus
+            
+            let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
+            let remainingData : NSMutableData = try parser.parse()
+            
+            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(parser.type == FastCGI.Constants.FCGI_END_REQUEST, "Record type received was incorrect")
+            XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
+            XCTAssert(parser.protocolStatus == protocolStatus, "Protocol status received incorrect.")
+            
+        }
+        catch {
+            XCTFail("Exception thrown: \(error)")
+        }
+    }
+    
+    // Test an FCGI_END_REQUEST record exchange with FCGI_REQUEST_COMPLETE (done/ok)
+    //
+    func testEndRequestSuccess() {
+        executeRequestEnd(protocolStatus: FastCGI.Constants.FCGI_REQUEST_COMPLETE)
+    }
+    
+    // Test an FCGI_END_REQUEST record exchange with FCGI_UNKNOWN_ROLE (requested role is unknown)
+    //
+    func testEndRequestUnknownRole() {
+        executeRequestEnd(protocolStatus: FastCGI.Constants.FCGI_UNKNOWN_ROLE)
+    }
+
+    // Test an FCGI_END_REQUEST record exchange with FCGI_CANT_MPX_CONN (multiplexing not available)
+    //
+    func testEndRequestCannotMultiplex() {
+        executeRequestEnd(protocolStatus: FastCGI.Constants.FCGI_CANT_MPX_CONN)
+    }
+
+    // Generate a block of random data for our test suite to use.
+    //
+    func generateRandomData(_ bytes: Int) -> NSData {
+        
+        #if os(Linux)            
+            let testData : NSMutableData = NSMutableData(capacity: bytes)!
+            for _ in 1...(bytes / sizeof(CLong)) {
+                var random : CLong = Glibc.random()
+                testData.append(&random, length: sizeof(CLong))
+            }
+            return testData
+        #else
+            let testData : NSMutableData = NSMutableData(length: bytes)!
+            Darwin.arc4random_buf(testData.mutableBytes, testData.length)
+            return testData
+        #endif
+        
+    }
+    
+    // Test an FCGI_STDOUT or FCGI_STDIN exchange with overly large bundle.
+    //
+    func executeOversizeDataExchangeTest(ofType: UInt8) {
+        
+        do {
+            // 128k worth of data
+            let testData : NSData = self.generateRandomData(128 * 1024)
+            
+            let creator : FastCGIRecordCreate = FastCGIRecordCreate()
+            creator.recordType = ofType
+            creator.requestId = 1
+            creator.data = testData
+            
+            let _ = try creator.create()
+            
+            XCTFail("Creator allowed the creation of an enormous payload (>64k)")
+            
+        }
+        catch FastCGI.RecordErrors.OversizeData {
+            // this is fine - is expected.
+        }
+        catch {
+            XCTFail("Exception thrown: \(error)")
+        }
+        
+    }
+    
+    // Test an FCGI_STDOUT record exchange with overly large bundle (forbidden)
+    //
+    func testOversizeDataOutput() {
+        executeOversizeDataExchangeTest(ofType: FastCGI.Constants.FCGI_STDOUT)
+    }
+    
+    // Test an FCGI_STDOUT record exchange with overly large bundle (forbidden)
+    //
+    func testOversizeDataInput() {
+        executeOversizeDataExchangeTest(ofType: FastCGI.Constants.FCGI_STDIN)
+    }
+    
+    // Test an FCGI_STDOUT or FCGI_STDIN record exchange
+    //
+    func executeDataExchangeTest(ofType: UInt8) {
+        
+        do {
+            let testData : NSData = self.generateRandomData(32 * 1024)
+            
+            let creator : FastCGIRecordCreate = FastCGIRecordCreate()
+            creator.recordType = ofType
+            creator.requestId = 1
+            creator.data = testData
+            
+            let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
+            let remainingData : NSMutableData = try parser.parse()
+            
+            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(parser.type == ofType, "Record type received was incorrect")
+            XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
+            XCTAssert(parser.data != nil, "No data was received")
+            
+            if (parser.data != nil) {
+                XCTAssert(testData.isEqual(to: parser.data!), "Data received was not data sent.")
+            }
+            
+        }
+        catch {
+            XCTFail("Exception thrown: \(error)")
+        }
+        
+    }
+    
+    // Test an FCGI_STDOUT record exchange
+    //
+    func testDataOutput() {
+        executeDataExchangeTest(ofType: FastCGI.Constants.FCGI_STDOUT)
+    }
+
+    // Test an FCGI_STDOUT record exchange
+    //
+    func testDataInput() {
+        executeDataExchangeTest(ofType: FastCGI.Constants.FCGI_STDIN)
+    }
+
+    // Test to verify that the record creator won't make absurd
+    // records. This is a casual test but it ensures basic sanity.
+    //
+    func testNoRequestId() {
+        
+        do {
+            let creator : FastCGIRecordCreate = FastCGIRecordCreate()
+            creator.recordType = FastCGI.Constants.FCGI_STDOUT
+            
+            var _ : NSData = try creator.create()
+            
+            XCTFail("Record creator allowed record with no record ID to be created.")
+        }
+        catch FastCGI.RecordErrors.InvalidRequestId {
+            // ignore this - expected behaviour
+        }
+        catch {
+            XCTFail("Record creator threw unexpected exception")
+        }
+        
+    }
+    
+    // Test to verify that the record creator won't make absurd
+    // records. This is a casual test but it ensures basic sanity.
+    //
+    func testBadRecordType() {
+        
+        do {
+            let creator : FastCGIRecordCreate = FastCGIRecordCreate()
+            creator.recordType = 111 // this is just insane
+            creator.requestId = 1
+            
+             var _ : NSData = try creator.create()
+            
+            XCTFail("Record creator allowed strange record to be created.")
+        }
+        catch FastCGI.RecordErrors.InvalidType {
+            // ignore this - expected behaviour
+        }
+        catch {
+            XCTFail("Record creator threw unexpected exception.")
+        }
+        
+    }
+    
+    // Perform a testRequestBeginXKeepalive() test.
+    //
+    // This tests to determine if the parser and encoder can create FCGI_BEGIN_REQUEST
+    // records that are interoperable.
+    //
+    func executeRequestBegin(keepalive: Bool) {
+        do {
+            let creator : FastCGIRecordCreate = FastCGIRecordCreate()
+            creator.recordType = FastCGI.Constants.FCGI_BEGIN_REQUEST
+            creator.requestId = 1
+            creator.requestRole = FastCGI.Constants.FCGI_RESPONDER
+            creator.keepAlive = keepalive
+            
+            let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
+            let remainingData : NSMutableData = try parser.parse()
+            
+            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(parser.type == FastCGI.Constants.FCGI_BEGIN_REQUEST, "Record type received was incorrect")
+            XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
+            XCTAssert(parser.role == FastCGI.Constants.FCGI_RESPONDER, "Role received was incorrect")
+            XCTAssert(parser.keepalive == keepalive, "Keep alive state was received incorrectly.")
+            
+        }
+        catch {
+            XCTFail("Exception thrown: \(error)")
+        }
+    }
+    
+    // Test an FCGI_BEGIN_REQUEST record exchange with keep alive requested.
+    //
+    func testRequestBeginKeepalive() {
+        self.executeRequestBegin(keepalive: true)
+    }
+
+    // Test an FCGI_BEGIN_REQUEST record exchange WITHOUT keep alive requested.
+    //
+    func testRequestBeginNoKeepalive() {
+        self.executeRequestBegin(keepalive: false)
+    }
+    
+    // Perform a parameter record test.
+    //
+    // This tests to determine if the parser and encoder can create FCGI_PARAMS
+    // records that are interoperable.
+    //
+    func testParameters() {
+        do {
+            // Make a long string
+            var longString : String = ""
+            
+            for _ in 1...256 {
+                longString = longString + "X"
+            }
+            
+            // create some parameters to tests
+            var params : [(String,String)] = []
+            
+            params.append(("SHORT_KEY_A", "SHORT_VALUE"))
+            params.append(("SHORT_KEY_B", "LONG_VALUE_" + longString))
+            params.append(("LONG_KEY_A_" + longString, "SHORT_VALUE"))
+            params.append(("LONG_KEY_A_" + longString, "LONG_VALUE_" + longString))
+            
+            // test sending those parameters
+            let creator : FastCGIRecordCreate = FastCGIRecordCreate()
+            creator.recordType = FastCGI.Constants.FCGI_PARAMS
+            creator.requestId = 1
+            
+            for currentHeader : (String,String) in params {
+                creator.params.append((currentHeader.0, currentHeader.1))
+            }
+            
+            let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
+            let remainingData : NSMutableData = try parser.parse()
+            
+            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(parser.type == FastCGI.Constants.FCGI_PARAMS, "Record type received was incorrect")
+            XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
+            
+            // Check what we received was what we expected.
+            for sourceHeader : (String,String) in params {
+                
+                var pairReceived : Bool = false
+                
+                for currentHeader : Dictionary<String,String> in parser.headers {
+                    
+                    let currentHeaderName : String = currentHeader["name"]!
+                    let currentHeaderValue : String = currentHeader["value"]!
+                    
+                    if currentHeaderName == sourceHeader.0 && currentHeaderValue == sourceHeader.1 {
+                        pairReceived = true
+                        break
+                    }
+                    
+                }
+                
+                XCTAssert(pairReceived, "Key \(sourceHeader.0), Value \(sourceHeader.1) sent but not received")
+                
+            }
+                    
+        }
+        catch {
+            XCTFail("Exception thrown: \(error)")
+        }
+    }
+
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -20,6 +20,7 @@ import XCTest
 
 XCTMain([
 	testCase(ClientE2ETests.allTests),
-  testCase(ClientRequestTests.allTests),
-	testCase(ParserTests.allTests)
+  	testCase(ClientRequestTests.allTests),
+	testCase(ParserTests.allTests),
+	testCase(FastCGIProtocolTests.allTests)
 ])


### PR DESCRIPTION
This PR includes the FastCGI protocol suite for Kitura and generalized the listener group system to support it.

## Description
- Added FastCGI classes, all prefixed with FastCGI in the file/class name. These classes are independent of other code.
- Created ListenerGroup.swift class with some static functionality. Both HTTPServer and FastCGIServer will enqueue their listeners against this new group rather than house their own groups internally.
- Modified HTTPServer to use ListenerGroup.
- Added a temporary waitForListeners() method in HTTPServer that simply forwards to the ListenerGroup waitForListeners() method. This allows this PR to Kitura-net to work with the current/tagged version of Kitura without breaking. I'll remove this later once Kitura has been updated to support FastCGI usage.

Note that applications won't be able to add FastCGI listeners until another PR goes through to Kitura that adds an "addFastCGIServer(onPort, withRouter)" call. This code is all the dependency code for that future PR.

## Motivation and Context
Implements core functionality in Kitura-net to support enhancement discussed in IBM-Swift/Kitura#565

## How Has This Been Tested?
- Includes test suite for protocol testing proper.
- Core code has been usage tested on Mac and Linux using Nginx (FastCGI) and Apache (proxy_fcgi) as gateway web servers.
- Benchmarks (given presence of Keep-Alive) in gateway web server:

Kitura HTTP:
```
$ ab -n 1000 -c 10 -l http://swift.codeandstrings.com:8080/
Requests per second:    129.46 [#/sec] (mean)
Time per request:       77.244 [ms] (mean)
```

Kitura FastCGI (Nginx) (No Keep Alive):
```
$ ab -n 1000 -c 10 -l http://swift.codeandstrings.com/
Requests per second:    121.42 [#/sec] (mean)
Time per request:       82.356 [ms] (mean)
```

Kitura FastCGI (Nginx) (Keep Alive to Nginx):
```
$ ab -n 1000 -c 10 -k -l http://swift.codeandstrings.com/
Requests per second:    555.32 [#/sec] (mean)
Time per request:       18.008 [ms] (mean)
```

Note: All tests over a WAN link to a data centre offsite from my test environment so Internet conditions apply but testing is generally repeatable.

Note: Load testing shows no leaks in Xcode and MacOS (10.11.5) but this code, like Kitura proper, seems to suffer at the hands of [SR-1552](https://github.com/apple/swift-corelibs-foundation/pull/380).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.