### PR TITLE
Issue 617

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.build
 /Packages
 /*.xcodeproj
+/Kitura-Build
+


### PR DESCRIPTION
Fix git clone recursive issue with dependencies. Issue IBM-Swift/Kitura#617

## Description
We never need to have Kitura-Build somehow point to a specific commit within the Kitura-Build repository. Lets always have our Makefile clone Kitura-Build's trunk.

## Motivation and Context
Builds are broken

## How Has This Been Tested?
Travis-CI build now works

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
