### PR TITLE
Corrected port issue with FastCGIServerRequest

### DIFF
--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -207,6 +207,9 @@ public class FastCGIServerRequest : ServerRequest {
             self.url.append(StringUtils.toUtf8String("://")! as Data)
         #endif
         
+        // detector for our port
+        var portPassedWithHostName : Bool = false
+        
         // set our host name
         //
         if self.requestHost?.characters.count > 0 {
@@ -218,6 +221,10 @@ public class FastCGIServerRequest : ServerRequest {
                 self.url.append(StringUtils.toUtf8String(self.requestHost!)! as Data)
             #endif
             
+            if self.requestHost!.contains(":") {
+                portPassedWithHostName = true
+            }
+            
         } else if self.requestServerName?.characters.count > 0 {
             
             // use the requested server name as received
@@ -227,6 +234,10 @@ public class FastCGIServerRequest : ServerRequest {
                 self.url.append(StringUtils.toUtf8String(self.requestServerName!)! as Data)
             #endif
             
+            if self.requestHost!.contains(":") {
+                portPassedWithHostName = true
+            }
+            
         } else if self.requestServerAddress?.characters.count > 0 {
             
             // use the requested server address as received
@@ -235,6 +246,10 @@ public class FastCGIServerRequest : ServerRequest {
             #else
                 self.url.append(StringUtils.toUtf8String(self.requestServerAddress!)! as Data)
            #endif
+            
+            if self.requestHost!.contains(":") {
+                portPassedWithHostName = true
+            }
             
         } else {
             
@@ -249,10 +264,13 @@ public class FastCGIServerRequest : ServerRequest {
         
         // set the port
         //
-        if self.requestPort?.characters.count > 0 {
+        if !portPassedWithHostName && self.requestPort?.characters.count > 0 {
             
-            // we received a port - we'll append it if it's not a standard
-            // HTTP port that is typically used (80, 443)
+            // We received a port (normaL) and no port was passed as part of our
+            // server address (probably means address is 80 or 443).
+            //
+            // We'll append our port if it's not a standard HTTP port 
+            // that is typically used (80, 443)
             //
             if !FastCGIServerRequest.defaultHttpPorts.contains(self.requestPort!) {
                 #if os(Linux)

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -266,11 +266,11 @@ public class FastCGIServerRequest : ServerRequest {
         //
         if !portPassedWithHostName && self.requestPort?.characters.count > 0 {
             
-            // We received a port (normaL) and no port was passed as part of our
-            // server address (probably means address is 80 or 443).
+            // We received a port via SERVER_PORT and no port was passed as part of our
+            // server address (probably means web address is port 80 or 443).
             //
-            // We'll append our port if it's not a standard HTTP port 
-            // that is typically used (80, 443)
+            // We'll append our port to the URL if the web server is not, in fact, using a 
+            // standard HTTP port (80, 443)
             //
             if !FastCGIServerRequest.defaultHttpPorts.contains(self.requestPort!) {
                 #if os(Linux)


### PR DESCRIPTION
Corrected a port issue with FastCGIServerRequest where the port being used by the web server is non-standard.

## Description
- Nginx and Apache pass the HTTP_HOST as "host:port" when the port involved is not 80 or 443.
- The previous logic ignored the possibility that the port was already included in the HTTP_HOST header and affixed a port if a non-standard web server port was received via SERVER_PORT.
- The result was a URL passed to Kitura of http://hostname:port:port/.

This patch corrects that logic to check the incoming host name (in HTTP_HOST or the passed server name/address) for an existing port. FastCGIServerRequest then suffixes a port number to the URL only if no port is found (in HTTP_HOST) and if the SERVER_PORT is non-standard.

## Motivation and Context
Without this patch, web servers running on non-standard ports fail when passing requests to Kitura.

## How Has This Been Tested?
http://swift.codeandstrings.com - standard port, Nginx -> FastCGI -> Kitura.
http://swift.codeandstrings.com:8080 - non-stnadard port, Apache -> FastCGI -> Kitura

Both work as expected now.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.