### PR TITLE
Tuning and Cleanup of FastCGI Code

### DIFF
--- a/Sources/KituraNet/FastCGIRecordCreate.swift
+++ b/Sources/KituraNet/FastCGIRecordCreate.swift
@@ -78,7 +78,7 @@ class FastCGIRecordCreate {
         let r = NSMutableData()
         
         var v : UInt8 = FastCGI.Constants.FASTCGI_PROTOCOL_VERSION
-        var t : UInt8 = self.recordType
+        var t : UInt8 = recordType
         var requestId : UInt16 = FastCGIRecordCreate.getNetworkByteOrderSmall(from: self.requestId)
         
         r.append(&v, length: 1)
@@ -124,7 +124,7 @@ class FastCGIRecordCreate {
         
         var contentLength : UInt16 = FastCGIRecordCreate.getNetworkByteOrderSmall(from: 8)
         var requestRole : UInt16 = FastCGIRecordCreate.getNetworkByteOrderSmall(from: self.requestRole)
-        var flags : UInt8 = self.keepAlive ? FastCGI.Constants.FCGI_KEEP_CONN : 0
+        var flags : UInt8 = keepAlive ? FastCGI.Constants.FCGI_KEEP_CONN : 0
         
         // content length
         data.append(&contentLength, length: 2)
@@ -170,7 +170,7 @@ class FastCGIRecordCreate {
         
         let content : NSMutableData = NSMutableData()
         
-        for (key, value) in self.parameters {
+        for (key, value) in parameters {
 
             // generate our key and value by converting to 
             // Data from String using UTF-8.
@@ -185,8 +185,8 @@ class FastCGIRecordCreate {
                 continue
             }
             
-            self.writeEncodedLength(length: keyData.length, into: content)
-            self.writeEncodedLength(length: valueData.length, into: content)
+            writeEncodedLength(length: keyData.length, into: content)
+            writeEncodedLength(length: valueData.length, into: content)
             
             #if os(Linux)
                 content.append(keyData)
@@ -204,8 +204,8 @@ class FastCGIRecordCreate {
     // Generate a parameters (PARAMS) record
     //
     private func finalizeParameters(data: NSMutableData) -> NSData {
-        self.data = self.createParameterRecords()
-        return self.finalizeDataRecord(data: data)
+        self.data = createParameterRecords()
+        return finalizeDataRecord(data: data)
     }
     
     //
@@ -229,7 +229,7 @@ class FastCGIRecordCreate {
         data.append(&paddingLengthEncoded, length: 1)
         
         // reserved space
-        self.appendZeroes(data: data, count: 1)
+        appendZeroes(data: data, count: 1)
         // write our data block
         #if os(Linux)
             data.append(contentData)
@@ -239,7 +239,7 @@ class FastCGIRecordCreate {
         
         // write any padding
         if paddingLength > 0 {
-            self.appendZeroes(data: data, count: paddingLength)
+            appendZeroes(data: data, count: paddingLength)
         }
         
         return data
@@ -252,7 +252,7 @@ class FastCGIRecordCreate {
         
         // check that our record type is ok
         //
-        switch self.recordType {
+        switch recordType {
         case FastCGI.Constants.FCGI_END_REQUEST,
              FastCGI.Constants.FCGI_STDOUT,
              FastCGI.Constants.FCGI_STDIN,
@@ -266,9 +266,9 @@ class FastCGIRecordCreate {
         
         // check that our subtype is ok, if applicable
         //
-        if self.recordType == FastCGI.Constants.FCGI_END_REQUEST {
+        if recordType == FastCGI.Constants.FCGI_END_REQUEST {
             
-            switch self.protocolStatus {
+            switch protocolStatus {
             case FastCGI.Constants.FCGI_REQUEST_COMPLETE,
                  FastCGI.Constants.FCGI_CANT_MPX_CONN,
                  FastCGI.Constants.FCGI_UNKNOWN_ROLE:
@@ -279,9 +279,9 @@ class FastCGIRecordCreate {
             }
             
         }
-        else if self.recordType == FastCGI.Constants.FCGI_BEGIN_REQUEST {
+        else if recordType == FastCGI.Constants.FCGI_BEGIN_REQUEST {
             
-            guard self.requestRole == FastCGI.Constants.FCGI_RESPONDER else {
+            guard requestRole == FastCGI.Constants.FCGI_RESPONDER else {
                 throw FastCGI.RecordErrors.invalidRole
             }
             
@@ -289,7 +289,7 @@ class FastCGIRecordCreate {
         
         // check that our request id is valid
         //
-        guard self.requestId != FastCGI.Constants.FASTCGI_DEFAULT_REQUEST_ID else {
+        guard requestId != FastCGI.Constants.FASTCGI_DEFAULT_REQUEST_ID else {
             throw FastCGI.RecordErrors.invalidRequestId
         }
         
@@ -313,21 +313,21 @@ class FastCGIRecordCreate {
         // rely on throw to abort if there is an issue
         try recordTest()
         
-        let record : NSMutableData = self.createRecordStarter()
+        let record : NSMutableData = createRecordStarter()
         
-        switch self.recordType {
+        switch recordType {
         case FastCGI.Constants.FCGI_BEGIN_REQUEST:
-            return self.finalizeRequestBeginRecord(data: record)
+            return finalizeRequestBeginRecord(data: record)
             
         case FastCGI.Constants.FCGI_END_REQUEST:
-            return self.finalizeRequestCompleteRecord(data: record)
+            return finalizeRequestCompleteRecord(data: record)
             
         case FastCGI.Constants.FCGI_PARAMS:
-            return self.finalizeParameters(data: record)
+            return finalizeParameters(data: record)
             
         default:
             // either STDIN or STDOUT
-            return self.finalizeDataRecord(data: record)
+            return finalizeDataRecord(data: record)
         }
         
     }

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -38,7 +38,7 @@ class FastCGIRecordParser {
     var protocolStatus : UInt8 = 0
     
     var keepalive : Bool {
-        return self.flags & FastCGI.Constants.FCGI_KEEP_CONN == 0 ? false : true
+        return flags & FastCGI.Constants.FCGI_KEEP_CONN == 0 ? false : true
     }
     
     // Internal Variables
@@ -58,12 +58,12 @@ class FastCGIRecordParser {
     //
     func advance() throws -> Int {
         
-        guard self.pointer < self.buffer.length else {
+        guard pointer < buffer.length else {
             throw FastCGI.RecordErrors.bufferExhausted
         }
         
-        let r = self.pointer
-        self.pointer += 1
+        let r = pointer
+        pointer += 1
         return r
     }
     
@@ -74,13 +74,13 @@ class FastCGIRecordParser {
     //
     func skip(_ count: Int) throws {
         
-        self.pointer += count
+        pointer += count
         
         // because we're skipping, it's ok to be pointer=length because we 
         // may never be reading again. but pointer=(length+x) is bad (where x>0)
         // because it means there aren't the bytes we expected
         //
-        guard self.pointer <= self.buffer.length else {
+        guard pointer <= buffer.length else {
             throw FastCGI.RecordErrors.bufferExhausted
         }
     }
@@ -120,9 +120,9 @@ class FastCGIRecordParser {
     // Parse FastCGI Version
     //
     private func parseVersion() throws {
-        self.version = self.bufferBytes[try advance()]
+        version = bufferBytes[try advance()]
         
-        guard self.version == FastCGI.Constants.FASTCGI_PROTOCOL_VERSION else {
+        guard version == FastCGI.Constants.FASTCGI_PROTOCOL_VERSION else {
             throw FastCGI.RecordErrors.invalidVersion
         }
     }
@@ -131,9 +131,9 @@ class FastCGIRecordParser {
     //
     private func parseType() throws {
         
-        self.type = self.bufferBytes[try advance()]
+        type = bufferBytes[try advance()]
         
-        switch self.type {
+        switch type {
         case FastCGI.Constants.FCGI_BEGIN_REQUEST,
              FastCGI.Constants.FCGI_END_REQUEST,
              FastCGI.Constants.FCGI_PARAMS,
@@ -151,11 +151,11 @@ class FastCGIRecordParser {
     //
     private func parseRequestId() throws {
         
-        let requestIdBytes1 = self.bufferBytes[try advance()]
-        let requestIdBytes0 = self.bufferBytes[try advance()]
+        let requestIdBytes1 = bufferBytes[try advance()]
+        let requestIdBytes0 = bufferBytes[try advance()]
         let requestIdBytes : [UInt8] = [ requestIdBytes1, requestIdBytes0 ]
         
-        self.requestId = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(requestIdBytes).pointee)
+        requestId = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(requestIdBytes).pointee)
         
     }
 
@@ -163,32 +163,32 @@ class FastCGIRecordParser {
     //
     private func parseContentLength() throws {
         
-        let contentLengthBytes1 = self.bufferBytes[try advance()]
-        let contentLengthBytes0 = self.bufferBytes[try advance()]
+        let contentLengthBytes1 = bufferBytes[try advance()]
+        let contentLengthBytes0 = bufferBytes[try advance()]
         let contentLengthBytes : [UInt8] = [ contentLengthBytes1, contentLengthBytes0 ]
         
-        self.contentLength = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(contentLengthBytes).pointee)
+        contentLength = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(contentLengthBytes).pointee)
         
     }
     
     // Parse padding length
     //
     private func parsePaddingLength() throws {
-        self.paddingLength = self.bufferBytes[try advance()]
+        paddingLength = bufferBytes[try advance()]
     }
 
     // Parse a role
     //
     private func parseRole() throws {
         
-        let roleByte1 = self.bufferBytes[try advance()]
-        let roleByte0 = self.bufferBytes[try advance()]
+        let roleByte1 = bufferBytes[try advance()]
+        let roleByte0 = bufferBytes[try advance()]
         let roleBytes : [UInt8] = [ roleByte1, roleByte0 ]
         
-        self.role = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(roleBytes).pointee)
-        self.flags = self.bufferBytes[try advance()]
+        role = FastCGIRecordParser.getLocalByteOrderSmall(from: UnsafePointer<UInt16>(roleBytes).pointee)
+        flags = bufferBytes[try advance()]
 
-        guard self.role == FastCGI.Constants.FCGI_RESPONDER else {
+        guard role == FastCGI.Constants.FCGI_RESPONDER else {
             throw FastCGI.RecordErrors.unsupportedRole
         }
         
@@ -198,30 +198,30 @@ class FastCGIRecordParser {
     //
     private func parseAppStatus() throws {
         
-        let appStatusByte3 = self.bufferBytes[try advance()]
-        let appStatusByte2 = self.bufferBytes[try advance()]
-        let appStatusByte1 = self.bufferBytes[try advance()]
-        let appStatusByte0 = self.bufferBytes[try advance()]
+        let appStatusByte3 = bufferBytes[try advance()]
+        let appStatusByte2 = bufferBytes[try advance()]
+        let appStatusByte1 = bufferBytes[try advance()]
+        let appStatusByte0 = bufferBytes[try advance()]
         let appStatusBytes : [UInt8] = [ appStatusByte3, appStatusByte2, appStatusByte1, appStatusByte0 ]
         
-        self.appStatus = FastCGIRecordParser.getLocalByteOrderLarge(from: UnsafePointer<UInt32>(appStatusBytes).pointee)
+        appStatus = FastCGIRecordParser.getLocalByteOrderLarge(from: UnsafePointer<UInt32>(appStatusBytes).pointee)
     
     }
     
     // Parse a protocol status
     //
     private func parseProtocolStatus() throws {
-        self.protocolStatus = self.bufferBytes[try advance()]
+        protocolStatus = bufferBytes[try advance()]
     }
     
     // Parse raw data from a data record
     //
     private func parseData() throws {
-        if self.contentLength > 0 {
-            self.data = NSData(bytes: self.bufferBytes + pointer, length: Int(self.contentLength))
-            try skip(Int(self.contentLength))
+        if contentLength > 0 {
+            data = NSData(bytes: bufferBytes + pointer, length: Int(contentLength))
+            try skip(Int(contentLength))
         } else {
-            self.data = NSData()
+            data = NSData()
         }
     }
     
@@ -248,7 +248,7 @@ class FastCGIRecordParser {
     //
     private func parseParameterLength() throws -> Int {
         
-        let lengthPeek : UInt8 = self.bufferBytes[try advance()]
+        let lengthPeek : UInt8 = bufferBytes[try advance()]
         
         if lengthPeek >> 7 == 0 {
             
@@ -264,9 +264,9 @@ class FastCGIRecordParser {
             // masked to created the correct value.
             //
             let lengthByteB3 : UInt8 = lengthPeek
-            let lengthByteB2 : UInt8 = self.bufferBytes[try advance()]
-            let lengthByteB1 : UInt8 = self.bufferBytes[try advance()]
-            let lengthByteB0 : UInt8 = self.bufferBytes[try advance()]
+            let lengthByteB2 : UInt8 = bufferBytes[try advance()]
+            let lengthByteB1 : UInt8 = bufferBytes[try advance()]
+            let lengthByteB0 : UInt8 = bufferBytes[try advance()]
             let lengthBytes : [UInt8] = [ lengthByteB3 & 0x7f, lengthByteB2, lengthByteB1, lengthByteB0 ]
 
             return Int(FastCGIRecordParser.getLocalByteOrderLarge(from: UnsafePointer<UInt32>(lengthBytes).pointee))
@@ -278,17 +278,17 @@ class FastCGIRecordParser {
     //
     private func parseParameters() throws {
         
-        guard self.contentLength > 0 else {
+        guard contentLength > 0 else {
             return
         }
         
-        var contentRemaining : Int = Int(self.contentLength)
+        var contentRemaining : Int = Int(contentLength)
         
         repeat {
             
-            let initialPointer : Int = self.pointer
-            let nameLength : Int = try self.parseParameterLength()
-            let valueLength : Int = try self.parseParameterLength()
+            let initialPointer : Int = pointer
+            let nameLength : Int = try parseParameterLength()
+            let valueLength : Int = try parseParameterLength()
             
             // capture the parameter name
             //
@@ -301,7 +301,7 @@ class FastCGIRecordParser {
             
             let currentPointer : Int = pointer
             try skip(nameLength)
-            let nameData = NSData(bytes: self.bufferBytes + currentPointer, length: nameLength)
+            let nameData = NSData(bytes: bufferBytes + currentPointer, length: nameLength)
             
             guard let nameString = StringUtils.fromUtf8String(nameData) else {
                 // the data received from the web server couldn't be transcoded
@@ -324,7 +324,7 @@ class FastCGIRecordParser {
                 
                 let currentPointer : Int = pointer
                 try skip(valueLength)
-                let valueData = NSData(bytes: self.bufferBytes + currentPointer, length: valueLength)
+                let valueData = NSData(bytes: bufferBytes + currentPointer, length: valueLength)
                 
                 guard let valueString = StringUtils.fromUtf8String(valueData) else {
                     // a value was supposed to have been provided but decoding it
@@ -335,17 +335,17 @@ class FastCGIRecordParser {
                 
                 // Done - store our paramter with the decoded value.
                 //
-                self.headers.append(["name": nameString, "value": valueString])
+                headers.append(["name": nameString, "value": valueString])
             }
             else {
                 // Done - store our paramter with the blank value (perfectly OK)
                 //
-                self.headers.append(["name": nameString, "value": ""])
+                headers.append(["name": nameString, "value": ""])
             }
             
             // adjust our position
             //
-            contentRemaining = contentRemaining - (self.pointer - initialPointer)
+            contentRemaining = contentRemaining - (pointer - initialPointer)
             
         }
         while contentRemaining > 0
@@ -357,16 +357,16 @@ class FastCGIRecordParser {
     //
     private func skipPaddingThenReturn() throws -> NSMutableData? {
         
-        if self.paddingLength > 0 {
-            try skip(Int(self.paddingLength))
+        if paddingLength > 0 {
+            try skip(Int(paddingLength))
         }
         
-        let remainingBufferBytes = self.buffer.length - self.pointer
+        let remainingBufferBytes = buffer.length - pointer
         
         if remainingBufferBytes == 0 {
             return nil
         } else {
-            return NSMutableData(bytes: buffer.bytes + self.pointer, length: remainingBufferBytes)
+            return NSMutableData(bytes: buffer.bytes + pointer, length: remainingBufferBytes)
         }
         
     }
@@ -387,7 +387,7 @@ class FastCGIRecordParser {
         try parsePaddingLength()
         try skip(1)
         
-        switch self.type {
+        switch type {
         case FastCGI.Constants.FCGI_BEGIN_REQUEST:
             try parseRole()
             try skip(5)

--- a/Sources/KituraNet/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGIRecordParser.swift
@@ -355,7 +355,7 @@ class FastCGIRecordParser {
     // Skip any padding indicated, then return the unused portion
     // of our data buffer. We're done reading this record.
     //
-    private func skipPaddingThenReturn() throws -> NSMutableData {
+    private func skipPaddingThenReturn() throws -> NSMutableData? {
         
         if self.paddingLength > 0 {
             try skip(Int(self.paddingLength))
@@ -364,7 +364,7 @@ class FastCGIRecordParser {
         let remainingBufferBytes = self.buffer.length - self.pointer
         
         if remainingBufferBytes == 0 {
-            return NSMutableData()
+            return nil
         } else {
             return NSMutableData(bytes: buffer.bytes + self.pointer, length: remainingBufferBytes)
         }
@@ -373,7 +373,7 @@ class FastCGIRecordParser {
     
     // Parser the data, return any extra
     //
-    func parse() throws -> NSMutableData {
+    func parse() throws -> NSMutableData? {
         
         // Make parser go now!
         //

--- a/Sources/KituraNet/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGIServer.swift
@@ -61,7 +61,7 @@ public class FastCGIServer {
         
         do {
             
-            self.listenSocket = try Socket.create()
+            listenSocket = try Socket.create()
             
         } catch let error as Socket.Error {
             print("FastCGI error reported:\n \(error.description)")

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -479,12 +479,17 @@ public class FastCGIServerRequest : ServerRequest {
                     // data yet.
                     //
                     do {
-                        let remainingData : NSData = try parser.parse()
-                        #if os(Linux)
-                            networkBuffer.setData(remainingData)
-                        #else
-                            networkBuffer.setData(remainingData as Data)
-                        #endif
+                        let remainingData : NSData? = try parser.parse()
+                        
+                        if (remainingData == nil) {
+                            networkBuffer.length = 0
+                        } else {
+                            #if os(Linux)
+                                networkBuffer.setData(remainingData!)
+                            #else
+                                networkBuffer.setData(remainingData as! Data)
+                            #endif
+                        }
                     }
                     catch FastCGI.RecordErrors.bufferExhausted {
                         // break out of this repeat, which will start the 

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -54,10 +54,10 @@ public class FastCGIServerRequest : ServerRequest {
     /// URL strings.
     ///
     public var urlString : String {
-        guard self.url.length > 0 else {
+        guard url.length > 0 else {
             return ""
         }
-        return StringUtils.fromUtf8String(self.url)!
+        return StringUtils.fromUtf8String(url)!
     }
     
     ///
@@ -127,14 +127,14 @@ public class FastCGIServerRequest : ServerRequest {
     // Read data received (perhaps from POST) into an NSData object
     //
     public func read(into data: NSMutableData) throws -> Int {
-        return self.bodyChunk.fill(data: data)
+        return bodyChunk.fill(data: data)
     }
     
     //
     // Read all data into the object.
     //
     public func readAllData(into data: NSMutableData) throws -> Int {
-        return self.bodyChunk.fill(data: data)
+        return bodyChunk.fill(data: data)
     }
     
     //
@@ -142,7 +142,7 @@ public class FastCGIServerRequest : ServerRequest {
     //
     public func readString() throws -> String? {
         let data : NSMutableData = NSMutableData()
-        let bytes : Int = self.bodyChunk.fill(data: data)
+        let bytes : Int = bodyChunk.fill(data: data)
         
         if bytes > 0 {
             return StringUtils.fromUtf8String(data)
@@ -158,24 +158,24 @@ public class FastCGIServerRequest : ServerRequest {
         
         // reset the current url
         //
-        self.url.length = 0
+        url.length = 0
         
         // set the uri
         //
-        if self.requestUri?.characters.count > 0 {
+        if requestUri?.characters.count > 0 {
             
             // use the URI as received
             #if os(Linux)
-                self.url.append(StringUtils.toUtf8String(self.requestUri!)!)
+                url.append(StringUtils.toUtf8String(requestUri!)!)
             #else
-                self.url.append(StringUtils.toUtf8String(self.requestUri!)! as Data)
+                url.append(StringUtils.toUtf8String(requestUri!)! as Data)
             #endif
         }
         else {
             #if os(Linux)
-                self.url.append(StringUtils.toUtf8String("/")!)
+                url.append(StringUtils.toUtf8String("/")!)
             #else
-                self.url.append(StringUtils.toUtf8String("/")! as Data)
+                url.append(StringUtils.toUtf8String("/")! as Data)
             #endif
         }
                 
@@ -189,17 +189,17 @@ public class FastCGIServerRequest : ServerRequest {
     private func postProcessParameters() {
         
         // make sure our method is set
-        if self.method.characters.count == 0 {
-            self.method = FastCGIServerRequest.defaultMethod
+        if method.characters.count == 0 {
+            method = FastCGIServerRequest.defaultMethod
         }
         
         // make sure our remoteAddress is set
-        if self.remoteAddress.characters.count == 0 {
-            self.remoteAddress = self.socket.remoteHostname
+        if remoteAddress.characters.count == 0 {
+            remoteAddress = socket.remoteHostname
         }
         
         // assign our URL
-        self.postProcessUrlParameter()
+        postProcessUrlParameter()
         
     }
     
@@ -216,7 +216,7 @@ public class FastCGIServerRequest : ServerRequest {
         processedName = processedName.replacingOccurrences(of: "_", with: "-")
         processedName = processedName.capitalized
         
-        self.headers.append(processedName as String, value: value)
+        headers.append(processedName as String, value: value)
     }
     
     //
@@ -264,8 +264,8 @@ public class FastCGIServerRequest : ServerRequest {
         
         // assign our values if applicable
         if majorVersion != nil && minorVersion != nil {
-            self.httpVersionMajor = majorVersion!
-            self.httpVersionMinor = minorVersion!
+            httpVersionMajor = majorVersion!
+            httpVersionMinor = minorVersion!
         }
     
     }
@@ -282,24 +282,24 @@ public class FastCGIServerRequest : ServerRequest {
         if name.caseInsensitiveCompare("REQUEST_METHOD") == .orderedSame {
             
             // The request method (GET/POST/etc)
-            self.method = value
+            method = value
             
         } else if name.caseInsensitiveCompare("REQUEST_URI") == .orderedSame {
             
             // The URI as submitted to the web server
-            self.requestUri = value
+            requestUri = value
             
         } else if name.caseInsensitiveCompare("REMOTE_ADDR") == .orderedSame {
             
             // The actual IP address of the client
-            self.remoteAddress = value
+            remoteAddress = value
             
         } else if name.caseInsensitiveCompare("SERVER_PROTOCOL") == .orderedSame {
             
             // The HTTP protocol used by the client to speak with the
-            // web server (HTTP/1.0, HTTP/1.1, HTTP/2.0, etc)
+            // web server (HTTP/0.9, HTTP/1.0, HTTP/1.1, HTTP/2.0, etc)
             //
-            self.processServerProtocol(value)
+            processServerProtocol(value)
             
         }
         else if name.hasPrefix("HTTP_") {
@@ -311,7 +311,7 @@ public class FastCGIServerRequest : ServerRequest {
             // added a second time by the "add all headers" catch-all at the
             // end of this block.
             //
-            self.processHttpHeader(name, value: value, remove: "HTTP_")
+            processHttpHeader(name, value: value, remove: "HTTP_")
             return
             
         }
@@ -321,7 +321,7 @@ public class FastCGIServerRequest : ServerRequest {
         //
         // Commented out for now pending community discussion as to best approach here
         
-        /* self.headers.append("FASTCGI_".appending(name), value: value) */
+        /* headers.append("FASTCGI_".appending(name), value: value) */
         
     }
     
@@ -333,18 +333,18 @@ public class FastCGIServerRequest : ServerRequest {
         // is this record for a request that is an extra
         // request that we've already seen? if so, ignore it.
         //
-        guard !self.extraRequestIds.contains(record.requestId) else {
+        guard !extraRequestIds.contains(record.requestId) else {
             return
         }
 
-        if self.status == Status.initial &&
+        if status == Status.initial &&
             record.type == FastCGI.Constants.FCGI_BEGIN_REQUEST {
             
             // this is a request begin record and we haven't seen any requests
             // in this FastCGIServerRequest object. We're safe to begin parsing.
             //
-            self.requestId = record.requestId
-            self.status = Status.requestStarted
+            requestId = record.requestId
+            status = Status.requestStarted
             
         }
         else if record.type == FastCGI.Constants.FCGI_BEGIN_REQUEST {
@@ -356,7 +356,7 @@ public class FastCGIServerRequest : ServerRequest {
             // if this is an extra begin request, we need to throw an error
             // and have the request 
             //
-            if record.requestId == self.requestId {
+            if record.requestId == requestId {
                 // a second begin request is insanity.
                 //
                 throw FastCGI.RecordErrors.protocolError
@@ -364,11 +364,11 @@ public class FastCGIServerRequest : ServerRequest {
                 // this is an attempt to multiplex the connection. remember this
                 // for later, as we can reject this safely with a response.
                 //
-                self.extraRequestIds.append(record.requestId)
+                extraRequestIds.append(record.requestId)
             }
             
         }
-        else if self.status == Status.requestStarted &&
+        else if status == Status.requestStarted &&
             record.type == FastCGI.Constants.FCGI_PARAMS {
             
             // this is a parameter record
@@ -380,14 +380,14 @@ public class FastCGIServerRequest : ServerRequest {
             // we want to keep processing the real request though, so we just 
             // ignore this for now and we can reject the attempt later.
             //
-            guard record.requestId == self.requestId else {
+            guard record.requestId == requestId else {
                 return
             }
             
             if record.headers.count > 0 {
                 for pair in record.headers  {
                     // parse the header we've received
-                    self.processHeader(pair["name"]!, value: pair["value"]!)
+                    processHeader(pair["name"]!, value: pair["value"]!)
                 }
             } else {
                 // no params were received in this parameter record.
@@ -397,12 +397,12 @@ public class FastCGIServerRequest : ServerRequest {
                 // process and we can reject this as an error state later
                 // as necessary.
                 //
-                self.postProcessParameters()
-                self.status = Status.headersComplete
+                postProcessParameters()
+                status = Status.headersComplete
             }
             
         }
-        else if self.status == Status.headersComplete &&
+        else if status == Status.headersComplete &&
             record.type == FastCGI.Constants.FCGI_STDIN {
             
             // Headers are complete and we're received STDIN records.
@@ -414,19 +414,19 @@ public class FastCGIServerRequest : ServerRequest {
             // we want to keep processing the real request though, so we just
             // ignore this for now and we can reject the attempt later.
             //
-            guard record.requestId == self.requestId else {
+            guard record.requestId == requestId else {
                 return
             }
             
             if record.data?.length > 0 {
                 // we've received some request body data as part of the STDIN
                 //
-                self.bodyChunk.append(data: record.data!)
+                bodyChunk.append(data: record.data!)
             }
             else {
                 // a zero length stdin means request is done
                 //
-                self.status = Status.requestComplete
+                status = Status.requestComplete
             }
             
         }
@@ -481,7 +481,7 @@ public class FastCGIServerRequest : ServerRequest {
                     do {
                         let remainingData : NSData? = try parser.parse()
                         
-                        if (remainingData == nil) {
+                        if remainingData == nil {
                             networkBuffer.length = 0
                         } else {
                             #if os(Linux)
@@ -503,10 +503,10 @@ public class FastCGIServerRequest : ServerRequest {
                     }
                     
                     // if we got here, we parsed a record.
-                    try self.processRecord(parser)
+                    try processRecord(parser)
                     
                     // if we're ready to send back a response, do so
-                    if self.status == Status.requestComplete {
+                    if status == Status.requestComplete {
                         callback(.success)
                         return
                     }

--- a/Sources/KituraNet/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGIServerRequest.swift
@@ -33,12 +33,12 @@ public class FastCGIServerRequest : ServerRequest {
     ///
     /// Major version for HTTP
     ///
-    public private(set) var httpVersionMajor: UInt16? = 1
+    public private(set) var httpVersionMajor: UInt16? = 0
     
     ///
     /// Minor version for HTTP
     ///
-    public private(set) var httpVersionMinor: UInt16? = 1
+    public private(set) var httpVersionMinor: UInt16? = 9
     
     ///
     /// Set of headers
@@ -234,7 +234,7 @@ public class FastCGIServerRequest : ServerRequest {
                 self.url.append(StringUtils.toUtf8String(self.requestServerName!)! as Data)
             #endif
             
-            if self.requestHost!.contains(":") {
+            if self.requestServerName!.contains(":") {
                 portPassedWithHostName = true
             }
             
@@ -247,7 +247,7 @@ public class FastCGIServerRequest : ServerRequest {
                 self.url.append(StringUtils.toUtf8String(self.requestServerAddress!)! as Data)
            #endif
             
-            if self.requestHost!.contains(":") {
+            if self.requestServerAddress!.contains(":") {
                 portPassedWithHostName = true
             }
             
@@ -340,6 +340,10 @@ public class FastCGIServerRequest : ServerRequest {
     // Parse the server protocol into a major and minor version
     //
     private func processServerProtocol(_ protocolString: String) {
+        
+        guard protocolString.characters.count > 0 else {
+            return
+        }
         
         guard protocolString.lowercased().hasPrefix("http/") &&
             protocolString.characters.count > "http/".characters.count else {

--- a/Sources/KituraNet/FastCGIServerResponse.swift
+++ b/Sources/KituraNet/FastCGIServerResponse.swift
@@ -76,7 +76,7 @@ public class FastCGIServerResponse : ServerResponse {
     init(socket: Socket, request: FastCGIServerRequest) {
         self.socket = socket
         self.serverRequest = request
-        headers["Date"] = [SPIUtils.httpDate()]
+        self.headers["Date"] = [SPIUtils.httpDate()]
     }
     
     
@@ -85,12 +85,12 @@ public class FastCGIServerResponse : ServerResponse {
     // They rely on other methods to do their work.
     //
     public func end(text: String) throws {
-        try self.write(from: text)
+        try write(from: text)
         try end()
     }
 
     public func write(from string: String) throws {
-        try self.write(from: StringUtils.toUtf8String(string)!)
+        try write(from: StringUtils.toUtf8String(string)!)
     }
     
     //
@@ -100,14 +100,14 @@ public class FastCGIServerResponse : ServerResponse {
         
         try startResponse()
         
-        if (self.buffer.length + data.length) > FastCGIServerResponse.bufferSize {
+        if (buffer.length + data.length) > FastCGIServerResponse.bufferSize {
             try flush()
         }
         
         #if os(Linux)
-            self.buffer.append(data)
+            buffer.append(data)
         #else
-            self.buffer.append(data as Data)
+            buffer.append(data as Data)
         #endif
     }
     
@@ -135,7 +135,7 @@ public class FastCGIServerResponse : ServerResponse {
         var headerData = ""
 
         // add our status header for FastCGI
-        headerData.append("Status: \(self.status) \(HTTP.statusCodes[self.status]!)\r\n")
+        headerData.append("Status: \(status) \(HTTP.statusCodes[status]!)\r\n")
 
         // add the rest of our response headers
         for (key, valueSet) in headers.headers {
@@ -180,8 +180,8 @@ public class FastCGIServerResponse : ServerResponse {
             throw FastCGI.RecordErrors.internalError
         }
         
-        return try self.getEndRequestMessage(requestId: serverRequest.requestId,
-                                             protocolStatus: FastCGI.Constants.FCGI_REQUEST_COMPLETE)
+        return try getEndRequestMessage(requestId: serverRequest.requestId,
+                                        protocolStatus: FastCGI.Constants.FCGI_REQUEST_COMPLETE)
         
     }
 
@@ -191,7 +191,7 @@ public class FastCGIServerResponse : ServerResponse {
     // beyond the first one until the first one is complete.
     //
     private func getNoMultiplexingMessage(requestId: UInt16) throws -> NSData {
-        return try self.getEndRequestMessage(requestId: requestId, protocolStatus: FastCGI.Constants.FCGI_CANT_MPX_CONN)
+        return try getEndRequestMessage(requestId: requestId, protocolStatus: FastCGI.Constants.FCGI_CANT_MPX_CONN)
     }
 
     //
@@ -210,7 +210,7 @@ public class FastCGIServerResponse : ServerResponse {
             throw FastCGI.RecordErrors.internalError
         }
         
-        return try self.getEndRequestMessage(requestId: requestId, protocolStatus: FastCGI.Constants.FCGI_UNKNOWN_ROLE)
+        return try getEndRequestMessage(requestId: requestId, protocolStatus: FastCGI.Constants.FCGI_UNKNOWN_ROLE)
         
     }
 
@@ -218,20 +218,20 @@ public class FastCGIServerResponse : ServerResponse {
     /// External message write for multiplex rejection    
     ///
     public func rejectMultiplexConnecton(requestId: UInt16) throws {
-        guard let message : NSData = try self.getNoMultiplexingMessage(requestId: requestId) else {
+        guard let message : NSData = try getNoMultiplexingMessage(requestId: requestId) else {
             return
         }
-        try self.writeToSocket(message, wrapAsMessage: false)
+        try writeToSocket(message, wrapAsMessage: false)
     }
     
     /// 
     /// External message write for role rejection
     ///
     public func rejectUnsupportedRole() throws {
-        guard let message : NSData = try self.getUnsupportedRoleMessage() else {
+        guard let message : NSData = try getUnsupportedRoleMessage() else {
             return
         }
-        try self.writeToSocket(message, wrapAsMessage: false)
+        try writeToSocket(message, wrapAsMessage: false)
     }
     
     ///
@@ -243,9 +243,9 @@ public class FastCGIServerResponse : ServerResponse {
         let record = FastCGIRecordCreate()
         
         record.recordType = FastCGI.Constants.FCGI_STDOUT
-        record.requestId = self.serverRequest!.requestId
+        record.requestId = serverRequest!.requestId
         
-        if (buffer != nil) {
+        if buffer != nil {
             record.data = buffer
         }
         
@@ -262,7 +262,7 @@ public class FastCGIServerResponse : ServerResponse {
             return
         }
 
-        if (wrapAsMessage) {
+        if wrapAsMessage {
             try socket.write(from: getMessage(buffer: data))
         } else {
             try socket.write(from: data)
@@ -276,12 +276,13 @@ public class FastCGIServerResponse : ServerResponse {
     ///
     private func flush() throws {
         
-        guard self.buffer.length > 0 else {
+        guard buffer.length > 0 else {
             return
         }
     
-        try self.writeToSocket(self.buffer)
-        self.buffer.length = 0
+        try writeToSocket(buffer)
+        
+        buffer.length = 0
         
     }
     
@@ -295,13 +296,13 @@ public class FastCGIServerResponse : ServerResponse {
     private func concludeResponse() throws {    
         
         // flush the reset of the buffer
-        try self.flush()
+        try flush()
         
         // send a blank packet
-        try self.writeToSocket(getMessage(buffer: nil), wrapAsMessage: false)
+        try writeToSocket(getMessage(buffer: nil), wrapAsMessage: false)
         
         // send done
-        try self.writeToSocket(getRequestCompleteMessage(), wrapAsMessage: false)
+        try writeToSocket(getRequestCompleteMessage(), wrapAsMessage: false)
         
         // close the socket.
         // we presently don't support keep-alive so this is fine.

--- a/Tests/KituraNet/FastCGIProtocolTests.swift
+++ b/Tests/KituraNet/FastCGIProtocolTests.swift
@@ -63,9 +63,9 @@ class FastCGIProtocolTests: XCTestCase {
             creator.protocolStatus = protocolStatus
             
             let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
-            let remainingData : NSMutableData = try parser.parse()
+            let remainingData : NSMutableData? = try parser.parse()
             
-            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(remainingData == nil, "Parser returned overflow data where not should have been present")
             XCTAssert(parser.type == FastCGI.Constants.FCGI_END_REQUEST, "Record type received was incorrect")
             XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
             XCTAssert(parser.protocolStatus == protocolStatus, "Protocol status received incorrect.")
@@ -165,9 +165,9 @@ class FastCGIProtocolTests: XCTestCase {
             creator.data = testData
             
             let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
-            let remainingData : NSMutableData = try parser.parse()
+            let remainingData : NSMutableData? = try parser.parse()
             
-            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(remainingData == nil, "Parser returned overflow data where not should have been present")
             XCTAssert(parser.type == ofType, "Record type received was incorrect")
             XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
             XCTAssert(parser.data != nil, "No data was received")
@@ -254,9 +254,9 @@ class FastCGIProtocolTests: XCTestCase {
             creator.keepAlive = keepalive
             
             let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
-            let remainingData : NSMutableData = try parser.parse()
+            let remainingData : NSMutableData? = try parser.parse()
             
-            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(remainingData == nil, "Parser returned overflow data where not should have been present")
             XCTAssert(parser.type == FastCGI.Constants.FCGI_BEGIN_REQUEST, "Record type received was incorrect")
             XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
             XCTAssert(parser.role == FastCGI.Constants.FCGI_RESPONDER, "Role received was incorrect")
@@ -312,9 +312,9 @@ class FastCGIProtocolTests: XCTestCase {
             }
             
             let parser : FastCGIRecordParser = FastCGIRecordParser.init(try creator.create())
-            let remainingData : NSMutableData = try parser.parse()
+            let remainingData : NSMutableData? = try parser.parse()
             
-            XCTAssert(remainingData.length == 0, "Parser returned overflow data where not should have been present")
+            XCTAssert(remainingData == nil, "Parser returned overflow data where not should have been present")
             XCTAssert(parser.type == FastCGI.Constants.FCGI_PARAMS, "Record type received was incorrect")
             XCTAssert(parser.requestId == 1, "Request ID received was incorrect")
             


### PR DESCRIPTION
PR to provide tuning and cleanup of FastCGI protocol implementation.

## Description
- Modified parser to assume HTTP/0.9 as the default, then parsing out actual protocol.
- Added detector for 0 length SERVER_PROTOCOL when rough HTTP/0.9 request arrives via FastCGI
- Simplified request URL processing down to simply URI use (same method as the HTTP server implementation) - bypasses potential host name / port parsing problems completely and removes associated processing overhead.
- Optimized logic where a block of data read from the socket would be returned from the FastCGI protocol parser as a zero length NSData() in order to signify the block was used completely. Now returns nil. Reduces NSData allocations non-trivially.
- Cleaned up code to removed stray self.X and ()'d if conditions (improved readability)

## Motivation and Context
Tuning and cleanup and overall code improvements.

## How Has This Been Tested?
Passes protocol test suite. Also load tested on both OS X and Linux with expected results.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes (tests updated)
