### PR TITLE
Swap HTTPParser Swift package for http-parser - issue #52

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,6 @@ let package = Package(
         .Package(url: "https://github.com/IBM-Swift/Kitura-sys.git", majorVersion: 0, minor: 22),
         .Package(url: "https://github.com/IBM-Swift/BlueSocket.git", majorVersion: 0, minor: 6),
         .Package(url: "https://github.com/IBM-Swift/CCurl.git", majorVersion: 0, minor: 2),
-        .Package(url: "https://github.com/IBM-Swift/CHTTPParser.git", majorVersion: 0, minor: 2),
+        .Package(url: "https://github.com/smithmicro/HTTPParser.git", majorVersion: 2, minor: 7)
     ]
 )

--- a/Sources/KituraNet/HTTPParser/URLParser.swift
+++ b/Sources/KituraNet/HTTPParser/URLParser.swift
@@ -121,11 +121,9 @@ public class URLParser : CustomStringConvertible {
     }
 
     ///
-    /// Path portion of the URL
+    /// Path portion of the URL - must be mutable as required by Kitura
     ///
-    public var path: String? {
-        return url?.path
-    }
+    public var path: String?
 
     ///
     /// The entire query portion of the URL
@@ -206,6 +204,10 @@ public class URLParser : CustomStringConvertible {
         #else
         url = NSURL(string: String(data: data as Data, encoding: String.Encoding.utf8) ?? "", relativeTo: nil)
         #endif
+
+        // set the initial path.  This can be changed by users.
+        path = url?.path
+        // parse query parameters
         if let query = url?.query {
 
             let pairs = query.components(separatedBy: "&")

--- a/Sources/KituraNet/HTTPParser/URLParser.swift
+++ b/Sources/KituraNet/HTTPParser/URLParser.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 // MARK: URLParser
-
+#if SR_1901_BUG
 public class URLParser : NSURL {
 
     /// 
@@ -31,7 +31,7 @@ public class URLParser : NSURL {
     ///
     /// The userid and password if specified in the URL
     ///
-    @available(*, deprecated: 0.23, message: "use user or password attributes instead")
+    @available(*, deprecated: 0.23, message: "use user and password attributes instead")
     
     public var userinfo: String? {
         // both are specified
@@ -100,3 +100,122 @@ public class URLParser : NSURL {
     }
 }
 
+#endif
+
+public class URLParser : CustomStringConvertible {
+
+    private var url: NSURL?
+
+    ///
+    /// Schema
+    ///
+    public var schema: String? {
+        return url?.scheme
+    }
+
+    ///
+    /// Hostname
+    ///
+    public var host: String? {
+        return url?.host
+    }
+
+    ///
+    /// Path portion of the URL
+    ///
+    public var path: String? {
+        return url?.path
+    }
+
+    ///
+    /// The entire query portion of the URL
+    ///
+    public var query: String? {
+        return url?.query
+    }
+
+    ///
+    /// TThe fragment
+    ///
+    public var fragment: String? {
+        return url?.fragment
+    }
+
+    ///
+    /// The userid and password if specified in the URL
+    ///
+    @available(*, deprecated: 0.23, message: "use user and password attributes instead")
+
+    public var userinfo: String? {
+        // both are specified
+        if let username = url?.user, let password = url?.password {
+            return username + ":" + password
+        }
+        // username only
+        if let username = url?.user {
+            return username
+        }
+        // password only
+        if let password = url?.user {
+            return ":" + password
+        }
+        return nil
+    }
+
+    public var user: String? {
+        return url?.user
+    }
+
+    public var password: String? {
+        return url?.password
+    }
+
+    ///
+    /// The port specified, if any, in the URL
+    ///
+    public var port: UInt16? {
+        return url?.port?.uint16Value
+    }
+
+    ///
+    /// The query parameters brokenn out
+    ///
+    public var queryParameters: [String:String] = [:]
+
+    ///
+    /// Nicely formatted description of the parsed result
+    ///
+    public var description: String {
+        if let description = url?.description {
+            return description
+        }
+        return ""
+    }
+
+
+    ///
+    /// Initializes a new URLParser instance
+    ///
+    /// - Parameter url: url to be parsed
+    /// - Parameter isConnect: whether or not a connection has been established
+    ///
+    public init (url data: NSData, isConnect: Bool) {
+
+        #if os(Linux)
+        url = NSURL(string: String(data: data, encoding: NSUTF8StringEncoding) ?? "", relativeToURL: nil)
+        #else
+        url = NSURL(string: String(data: data as Data, encoding: String.Encoding.utf8) ?? "", relativeTo: nil)
+        #endif
+        if let query = url?.query {
+
+            let pairs = query.components(separatedBy: "&")
+            for pair in pairs {
+
+                let pairArray = pair.components(separatedBy: "=")
+                if pairArray.count == 2 {
+                    queryParameters[pairArray[0]] = pairArray[1]
+                }
+            }
+        }
+    }
+}

--- a/Tests/KituraNet/ParserTests.swift
+++ b/Tests/KituraNet/ParserTests.swift
@@ -37,6 +37,7 @@ class ParserTests: XCTestCase {
         XCTAssertEqual(urlParser.schema!, "https", "Incorrect schema")
         XCTAssertEqual(urlParser.host!, "example.org", "Incorrect host")
         XCTAssertEqual(urlParser.path!, "/absolute/URI/with/absolute/path/to/resource.txt", "Incorrect path")
+        XCTAssert(urlParser.port == nil)
     }
     
     func testParseComplexUrl() {
@@ -51,6 +52,8 @@ class ParserTests: XCTestCase {
         XCTAssertEqual(urlParser.path!, "/path/data", "Incorrect path")
         XCTAssertEqual(urlParser.port!, 123, "Incorrect port")
         XCTAssertEqual(urlParser.fragment!, "fragid1", "Incorrect fragment")
+        XCTAssertEqual(urlParser.user!, "username", "Incorrect username")
+        XCTAssertEqual(urlParser.password!, "password", "Incorrect username:password")
         XCTAssertEqual(urlParser.userinfo!, "username:password", "Incorrect userinfo")
         XCTAssertEqual(urlParser.queryParameters["key"], "value", "Incorrect query")
         XCTAssertEqual(urlParser.queryParameters["key1"], "value1", "Incorrect query")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+test:
+  image: ibmcom/swift-ubuntu
+  volumes:
+    - ./:/test/
+  command: bash -c "make clean -C /test && make -C /test && make test -C /test"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Swapped Swift HTTPParser for 'C' http-parser ("CHTTPParser").  HTTPParser is a direct port of http-parser with the goal of being as maintainable as possible.

## Motivation and Context
This was initially a thought experiment, but the performance of HTTPParser was only 1.4 times slower than http-parser.  It processes over 500K requests per second using the 'bench' tool in Release mode.  Performance tuning continues.

We also noticed that the CHTTPParser module was causing Xcode compile issues for new Kitura developers.

## To Do
* Performance comparisons between Kitura based apps using HTTPParser vs CHTTPParser
* Test use of NSData bytesNoCopy inside of HTTPParser callbacks within Kitura-net.

## How Has This Been Tested?
Kitura-net unit tests pass on Linux and Mac
Kitura unit tests pass on Linux and Mac

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
