### PR TITLE
Fix for Issue IBM-Swift/Kitura#642

### DIFF
--- a/Sources/KituraNet/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTPIncomingMessage.swift
@@ -124,7 +124,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
         }
         
         var start = 0
-        while status.state == .initial  &&  length > 0  {
+        while status.state == .initial  &&  status.error == nil  &&  length > 0  {
             
             let (numberParsed, upgrade) = parser.execute(UnsafePointer<Int8>(buffer.bytes)+start, length: length)
             if upgrade == 1 {

--- a/Sources/KituraNet/IncomingHTTPSocketHandler.swift
+++ b/Sources/KituraNet/IncomingHTTPSocketHandler.swift
@@ -159,7 +159,17 @@ class IncomingHTTPSocketHandler: IncomingSocketHandler {
     /// convert the HTTP parser's status to our own.
     private func parse(_ buffer: NSData) {
         let parsingStatus = request.parse(buffer)
-        guard  parsingStatus.error == nil  else  { return }
+        guard  parsingStatus.error == nil  else  {
+            Log.error("Failed to parse a request")
+            if  let response = response {
+                response.statusCode = .badRequest
+                do {
+                    try response.end()
+                }
+                catch {}
+            }
+            return
+        }
         
         switch(parsingStatus.state) {
         case .initial:

--- a/Tests/KituraNet/ClientE2ETests.swift
+++ b/Tests/KituraNet/ClientE2ETests.swift
@@ -26,7 +26,8 @@ class ClientE2ETests: XCTestCase {
     static var allTests : [(String, (ClientE2ETests) -> () throws -> Void)] {
         return [
             ("testSimpleHTTPClient", testSimpleHTTPClient),
-            ("testPostRequests", testPostRequests)
+            ("testPostRequests", testPostRequests),
+            ("testErrorRequests", testErrorRequests)
         ]
     }
     
@@ -100,6 +101,16 @@ class ClientE2ETests: XCTestCase {
             }
         })
     }
+    
+    func testErrorRequests() {
+        performServerTest(delegate, asyncTasks: { expectation in
+            self.performRequest("plover", path: "/xzzy", callback: {response in
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.badRequest, "Status code wasn't .badrequest was \(response!.statusCode)")
+                expectation.fulfill()
+            })
+        })
+    }
+    
     
     class TestServerDelegate : ServerDelegate {
     


### PR DESCRIPTION
Properly handle HTTP request parse failures.

## Description
Break out of parse loop in case of parse error and send back a response with a status code of .badRequest

## Motivation and Context
Bug. Currently gets into an infinite loop.

## How Has This Been Tested?
Added a test that sends an invalid request.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
