### PR TITLE
Fixed: SPIUtils.httpDate(_) left a visible Optional() on macOS

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -121,6 +121,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
         if  status.state == .reset  {
             status.reset()
             parser.reset()
+            headers.removeAll()
         }
         
         var start = 0

--- a/Sources/KituraNet/SPIUtils.swift
+++ b/Sources/KituraNet/SPIUtils.swift
@@ -75,6 +75,7 @@ public class SPIUtils {
             let wday = Int(components.weekday)
             let mday = Int(components.day)
             let mon = Int(components.month)
+            let year = components.year
             let hour = Int(components.hour)
             let min = Int(components.minute)
             let sec = Int(components.second)
@@ -86,11 +87,12 @@ public class SPIUtils {
             let wday = Int(components.weekday!)
             let mday = Int(components.day!)
             let mon = Int(components.month!)
+            let year = components.year!
             let hour = Int(components.hour!)
             let min = Int(components.minute!)
             let sec = Int(components.second!)
         #endif
-        return "\(days[wday-1]), \(twoDigit(mday)) \(months[mon-1]) \(components.year) \(twoDigit(hour)):\(twoDigit(min)):\(twoDigit(sec)) GMT"
+        return "\(days[wday-1]), \(twoDigit(mday)) \(months[mon-1]) \(year) \(twoDigit(hour)):\(twoDigit(min)):\(twoDigit(sec)) GMT"
     }
 
     ///

--- a/Tests/KituraNet/SPIUtilsTests.swift
+++ b/Tests/KituraNet/SPIUtilsTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+import XCTest
+
+@testable import KituraNet
+
+class SPIUtilsTests: XCTestCase {
+
+#if os(Linux)
+    typealias Date = NSDate
+#endif
+
+    static var allTests : [(String, (SPIUtilsTests) -> () throws -> Void)] {
+        return [
+            ("testHttpDate", testHttpDate),
+        ]
+    }
+
+    func testHttpDate() {
+
+        // Fri, 07 Aug 2009 12:34:56 GMT
+        let date = Date(timeIntervalSince1970:1249648496)
+
+        let httpDate = SPIUtils.httpDate(date)
+
+        XCTAssertEqual("Fri, 07 Aug 2009 12:34:56 GMT", httpDate, "HTTP Date did not correctly format date")
+
+    }
+
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,5 +23,6 @@ XCTMain([
        testCase(ClientRequestTests.allTests),
        testCase(LargePayloadTests.allTests),
        testCase(ParserTests.allTests),
-       testCase(FastCGIProtocolTests.allTests)
+       testCase(FastCGIProtocolTests.allTests),
+       testCase(SPIUtilsTests.allTests)
 ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
SPIUtils.httpDate(_) would give output containing an Optional() around the year. For example,

```swift
let date = Date(timeIntervalSince1970:1249648496)
print(SPIUtils.httpDate(date))
```

prints the string `Fri, 07 Aug Optional(2009) 12:34:56 GMT`. This is obviously not a valid HTTP date.

## Description
<!--- Describe your changes in detail -->
These changes simply unwrap the optional into a new variable called `year` and use that in the format string instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Kitura uses httpDate to set the value for a cookie's expiration, which was not a valid HTTP date.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
A test case has been added to test the new code and ensure that httpDate(_) returns a valid HTTP date.

Testing has been performed on macOS, since that was the origin of the bug. To be honest, I'm not totally sure *how* to test on Linux, as I don't have a Linux box at my disposal. I'm sure there's some kind of magical Docker thing I could do..?

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.