### PR TITLE
IBM-Swift/Kitura#667 Correct the way HTTPIncomingMessage is reset

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -119,8 +119,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
         
         // If we were reset because of keep alive
         if  status.state == .reset  {
-            status.reset()
-            parser.reset()
+            reallyReset()
         }
         
         var start = 0
@@ -134,9 +133,8 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
                 
                 if  status.state == .reset  {
                     // Apparently the short message was a Continue. Let's just keep on parsing
-                    status.state = .initial
                     start = numberParsed
-                    parser.reset()
+                    reallyReset()
                 }
                 else {
                     /* Handle error. Usually just close the connection. */
@@ -372,13 +370,20 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
         }
     }
 
-    /// instructions for when reading is reset
+    /// Signal that reading is being reset
     func reset() {
-        lastHeaderWasAValue = false
-        url.length = 0
         status.state = .reset
     }
 
+    /// When we're ready, really reset everything
+    private func reallyReset() {
+        lastHeaderWasAValue = false
+        url.length = 0
+        headers.removeAll()
+        bodyChunk.reset()
+        status.reset()
+        httpParser?.reset()
+    }
 }
 
 

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -119,7 +119,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
         
         // If we were reset because of keep alive
         if  status.state == .reset  {
-            reallyReset()
+            reset()
         }
         
         var start = 0
@@ -134,7 +134,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
                 if  status.state == .reset  {
                     // Apparently the short message was a Continue. Let's just keep on parsing
                     start = numberParsed
-                    reallyReset()
+                    reset()
                 }
                 else {
                     /* Handle error. Usually just close the connection. */
@@ -371,12 +371,12 @@ public class HTTPIncomingMessage : HTTPParserDelegate, SocketReader {
     }
 
     /// Signal that reading is being reset
-    func reset() {
+    func prepareToReset() {
         status.state = .reset
     }
 
     /// When we're ready, really reset everything
-    private func reallyReset() {
+    private func reset() {
         lastHeaderWasAValue = false
         url.length = 0
         headers.removeAll()

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -84,7 +84,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     public func process(_ buffer: NSData) {
         switch(state) {
         case .reset:
-            request.reset()
+            request.prepareToReset()
             response.reset()
             fallthrough
             

--- a/Sources/KituraNet/HTTPParser/HTTPParser.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParser.swift
@@ -129,7 +129,7 @@ class HTTPParser {
         settings.on_message_complete = { (parser) -> Int32 in
             let p = UnsafePointer<HTTPParserDelegate?>(parser?.pointee.data)
             if get_status_code(parser) == 100 {
-                p?.pointee?.reset()
+                p?.pointee?.prepareToReset()
             }
             else {
                 p?.pointee?.onMessageComplete()
@@ -183,5 +183,5 @@ protocol HTTPParserDelegate: class {
     func onMessageBegin()
     func onMessageComplete()
     func onBody(_ body: NSData)
-    func reset()    
+    func prepareToReset()    
 }


### PR DESCRIPTION
Properly reset a HTTPServerRequest and/or ClientResponse when they are "reused".

## Description
When a connection is reused, the HTTPServerRequest object is reused for the following request. Similarly when parsing the response to a ClientRequest and a Continue status code was found, the ClientResponse object is reused.

In both cases the reset was incorrectly done, in the shared super-class HTTPIncomingMessage.

## Motivation and Context
Resolves issue IBM-Swift/Kitura#667

## How Has This Been Tested?
Ran the test case written the issue reporter as well a the TechPower test.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
