### PR TITLE
Fix for Issues #30 and #68

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -149,7 +149,7 @@ public class ClientRequest {
     /// Set a single option in the request.  URL parameters must be set in init()
     ///
     /// - Parameter option: an option describing the request
-    func set(_ option: Options) {
+    public func set(_ option: Options) {
 
         switch(option) {
         case .schema, .hostname, .port, .path, .username, .password:
@@ -165,6 +165,64 @@ public class ClientRequest {
         case .disableSSLVerification:
             self.disableSSLVerification = true
         }
+    }
+
+    /// Parse an URL String into options
+    ///
+    /// - Parameter urlString: URL of a String type
+    ///
+    /// - Returns: a ClientRequest.Options array
+    public class func parse(_ urlString: String) -> [ClientRequest.Options] {
+
+        if let url = URL(string: urlString) {
+            return parse(url)
+        }
+        return []
+    }
+
+    /// Parse an URL class into options
+    ///
+    /// - Parameter url: Foundation URL class
+    ///
+    /// - Returns: a ClientRequest.Options array
+    public class func parse(_ url: URL) -> [ClientRequest.Options] {
+
+        var options: [ClientRequest.Options] = []
+
+        if let scheme = url.scheme {
+            options.append(.schema("\(scheme)://"))
+        }
+        if let host = url.host {
+            options.append(.hostname(host))
+        }
+        #if os(Linux)
+            if var fullPath = url.path {
+                // query strings and parameters need to be appended here
+                if let query = url.query {
+                    fullPath += "?"
+                    fullPath += query
+                }
+                options.append(.path(fullPath))
+            }
+        #else
+            var fullPath = url.path
+            // query strings and parameters need to be appended here
+            if let query = url.query {
+                fullPath += "?"
+                fullPath += query
+            }
+            options.append(.path(fullPath))
+        #endif
+        if let port = url.port {
+            options.append(.port(Int16(port)))
+        }
+        if let username = url.user {
+            options.append(.username(username))
+        }
+        if let password = url.password {
+            options.append(.password(password))
+        }
+        return options
     }
 
     /// Instance destruction

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -33,7 +33,7 @@ public class ClientRequest {
     // MARK: -- Private
     
     /// URL used for the request
-    public private(set) var url: String
+    public private(set) var url: String = ""
     
     /// HTTP method (GET, POST, PUT, DELETE) for the request
     public private(set) var method: String = "get"
@@ -110,8 +110,9 @@ public class ClientRequest {
         for option in options  {
             switch(option) {
 
-                case .method(let method):
-                    self.method = method
+                case .method, .headers, .maxRedirects, .disableSSLVerification:
+                    // call set() for Options that do not construct the URL
+                    set(option)
                 case .schema(var schema):
                     if !schema.contains("://") && !schema.isEmpty {
                       schema += "://"
@@ -126,18 +127,10 @@ public class ClientRequest {
                       thePath = "/" + thePath
                     }
                     path = thePath
-                case .headers(let headers):
-                    for (key, value) in headers {
-                        self.headers[key] = value
-                    }
                 case .username(let userName):
                     self.userName = userName
                 case .password(let password):
                     self.password = password
-                case .maxRedirects(let maxRedirects):
-                    self.maxRedirects = maxRedirects
-                case .disableSSLVerification:
-                    self.disableSSLVerification = true
             }
         }
 
@@ -151,6 +144,27 @@ public class ClientRequest {
 
         url = "\(theSchema)\(authenticationClause)\(hostName)\(port)\(path)"
 
+    }
+
+    /// Set a single option in the request.  URL parameters must be set in init()
+    ///
+    /// - Parameter option: an option describing the request
+    func set(_ option: Options) {
+
+        switch(option) {
+        case .schema, .hostname, .port, .path, .username, .password:
+            Log.error("Must use ClientRequest.init() to set URL components")
+        case .method(let method):
+            self.method = method
+        case .headers(let headers):
+            for (key, value) in headers {
+                self.headers[key] = value
+            }
+        case .maxRedirects(let maxRedirects):
+            self.maxRedirects = maxRedirects
+        case .disableSSLVerification:
+            self.disableSSLVerification = true
+        }
     }
 
     /// Instance destruction

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -104,7 +104,7 @@ class ClientRequestTests: XCTestCase {
     XCTAssertEqual(testRequest.url, "https://66o.tech:8080")
   }
 
-  func testClientRequestPrase() {
+  func testClientRequestParse() {
 
     let options = ClientRequest.parse("https://username:password@66o.tech:8080/path")
     let testRequest = ClientRequest(options: options, callback: testCallback)
@@ -125,7 +125,7 @@ extension ClientRequestTests {
              ("testClientRequestAppendsMisformattedPathCorrectly", testClientRequestAppendsMisformattedPathCorrectly),
              ("testClientRequestAppendsPort", testClientRequestAppendsPort),
              ("testClientRequestSet", testClientRequestSet),
-             ("testClientRequestPrase", testClientRequestPrase)
+             ("testClientRequestParse", testClientRequestParse)
     ]
   }
 }

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -90,7 +90,20 @@ class ClientRequestTests: XCTestCase {
     
     XCTAssertEqual(testRequest.url, "https://66o.tech:8080")
   }
-  
+
+  func testClientRequestSet() {
+
+    let testRequest = ClientRequest(url: "https://66o.tech:8080", callback: testCallback)
+
+    // ensure setting non-URL options does not effect the URL
+    testRequest.set(.method("delete"))
+    testRequest.set(.headers(["X-Custom": "Swift"]))
+    testRequest.set(.maxRedirects(3))
+    testRequest.set(.disableSSLVerification)
+
+    XCTAssertEqual(testRequest.url, "https://66o.tech:8080")
+  }
+
 }
 
 extension ClientRequestTests {
@@ -103,7 +116,8 @@ extension ClientRequestTests {
              ("testClientRequestDefaultMethodIsGET", testClientRequestDefaultMethodIsGET),
              ("testClientRequestAppendsPathCorrectly", testClientRequestAppendsPathCorrectly),
              ("testClientRequestAppendsMisformattedPathCorrectly", testClientRequestAppendsMisformattedPathCorrectly),
-             ("testClientRequestAppendsPort", testClientRequestAppendsPort)
+             ("testClientRequestAppendsPort", testClientRequestAppendsPort),
+             ("testClientRequestSet", testClientRequestSet)
     ]
   }
 }

--- a/Tests/KituraNet/ClientRequestTests.swift
+++ b/Tests/KituraNet/ClientRequestTests.swift
@@ -104,6 +104,13 @@ class ClientRequestTests: XCTestCase {
     XCTAssertEqual(testRequest.url, "https://66o.tech:8080")
   }
 
+  func testClientRequestPrase() {
+
+    let options = ClientRequest.parse("https://username:password@66o.tech:8080/path")
+    let testRequest = ClientRequest(options: options, callback: testCallback)
+    XCTAssertEqual(testRequest.url, "https://username:password@66o.tech:8080/path")
+  }
+
 }
 
 extension ClientRequestTests {
@@ -117,7 +124,8 @@ extension ClientRequestTests {
              ("testClientRequestAppendsPathCorrectly", testClientRequestAppendsPathCorrectly),
              ("testClientRequestAppendsMisformattedPathCorrectly", testClientRequestAppendsMisformattedPathCorrectly),
              ("testClientRequestAppendsPort", testClientRequestAppendsPort),
-             ("testClientRequestSet", testClientRequestSet)
+             ("testClientRequestSet", testClientRequestSet),
+             ("testClientRequestPrase", testClientRequestPrase)
     ]
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Allow for more flexibility with ClientRequest to be used with other verbs, or when you bring your own constructed URL
* Proposed fix for "Connection: close" issue

## Motivation and Context
Fix for #30:
* Backwards compatible - a new RequestOptions member was not added, existing APIs not changed
* Allows users to set parameters after class initialization without affecting the URL
* Allows for bringing a URL string or URL class to start with.  Allows easy adding of username/password options to an existing URL.

Fix for #66 
* Proposing a fix that makes a "Connection: close" optional and off by default.  All unit tests pass with "Connection: close" turned off.
* optional parameter on end() functions to instruct the class to close the connection

## How Has This Been Tested?
Passes unit tests for Kitura-Net and Kitura

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
