### PR TITLE
Resolution of Issue 678

### DIFF
--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -98,7 +98,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     
     /// Close the socket and mark this handler as no longer in progress.
     public func close() {
-        handler?.close()
+        handler?.prepareToClose()
     }
     
     /// Invoke the HTTP parser against the specified buffer of data and

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -36,21 +36,21 @@ public class IncomingSocketHandler {
     #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
         typealias DispatchSourceReadType = DispatchSourceRead
         typealias DispatchSourceWriteType = DispatchSourceWrite
-        static let socketReaderWriterQueue = DispatchQueue(label: "Socket ReaderWriter")
-        private let writeBufferLock = DispatchSemaphore(value: 1)
+        static let socketReaderQueue = DispatchQueue(label: "Socket Reader")
+        static let socketWriterQueue = DispatchQueue(label: "Socket Writer")
     #else
         #if GCD_ASYNCH
             typealias DispatchSourceReadType = dispatch_source_t
             typealias DispatchSourceWriteType = dispatch_source_t
-            static let socketReaderWriterQueue = dispatch_queue_create("Socket ReaderWriter", DISPATCH_QUEUE_SERIAL)
+            static let socketReaderQueue = dispatch_queue_create("Socket Reader", DISPATCH_QUEUE_SERIAL)
         #endif
-        private let writeBufferLock: dispatch_semaphore_t!
+        static let socketWriterQueue = dispatch_queue_create("Socket Writer", DISPATCH_QUEUE_SERIAL)
     #endif
     
     #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
         // Note: This var is optional to enable it to be constructed in the init function
         var readerSource: DispatchSourceReadType!
-        var writerSource: DispatchSourceWriteType!
+        var writerSource: DispatchSourceWriteType?
     #endif
 
     let socket: Socket
@@ -68,7 +68,7 @@ public class IncomingSocketHandler {
         
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
             readerSource = DispatchSource.makeReadSource(fileDescriptor: socket.socketfd,
-                                                         queue: IncomingSocketHandler.socketReaderWriterQueue)
+                                                         queue: IncomingSocketHandler.socketReaderQueue)
         
             readerSource.setEventHandler() {
                 self.handleRead()
@@ -77,17 +77,9 @@ public class IncomingSocketHandler {
                 self.handleCancel()
             }
             readerSource.resume()
-            
-            writerSource = DispatchSource.makeWriteSource(fileDescriptor: socket.socketfd,
-                                                          queue: IncomingSocketHandler.socketReaderWriterQueue)
-            
-            writerSource.setEventHandler() {
-                self.handleWrite()
-            }
-            writerSource.resume()
         #elseif GCD_ASYNCH
             readerSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, UInt(socket.socketfd), 0,
-		                                          IncomingSocketHandler.socketReaderWriterQueue)
+		                                          IncomingSocketHandler.socketReaderQueue)
 
             dispatch_source_set_event_handler(readerSource) {
                 self.handleRead()
@@ -96,18 +88,6 @@ public class IncomingSocketHandler {
                 self.handleCancel()
             }
             dispatch_resume(readerSource)
-            
-            writerSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_WRITE, UInt(socket.socketfd), 0,
-                                                  IncomingSocketHandler.socketReaderWriterQueue)
-            
-            dispatch_source_set_event_handler(writerSource) {
-                self.handleRead()
-            }
-            dispatch_resume(writerSource)
-        #endif
-        
-        #if os(Linux)
-            writeBufferLock = dispatch_semaphore_create(1)
         #endif
         
         processor?.handler = self
@@ -138,10 +118,19 @@ public class IncomingSocketHandler {
         }
     }
     
-    /// Write out any buffered data now that the sockt can accept more data
+    /// Write out any buffered data now that the socket can accept more data
     func handleWrite() {
+        #if !GCD_ASYNCH  &&  os(Linux)
+            dispatch_sync(IncomingSocketHandler.socketWriterQueue) { [unowned self] in
+                self.handleWriteHelper()
+            }
+        #endif
+    }
+    
+    /// Inner function to write out any buffered data now that the socket can accept more data,
+    /// invoked in serial queue.
+    private func handleWriteHelper() {
         if  writeBuffer.count != 0 {
-            lockWriteBufferLock()
             do {
                 let written = try socket.write(from: writeBuffer)
                 
@@ -155,7 +144,16 @@ public class IncomingSocketHandler {
             catch {
                 Log.error("Write to socket (file descriptor \(socket.socketfd) failed. Error number=\(errno). Message=\(errorString(error: errno)).")
             }
-            unlockWriteBufferLock()
+            
+            #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
+                if writeBuffer.count == 0, let writerSource = writerSource {
+                    #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
+                        writerSource.cancel()
+                    #elseif GCD_ASYNCH
+                        dispatch_source_cancel(writerSource)
+                    #endif
+                }
+            #endif
         }
         
         if preparingToClose {
@@ -163,21 +161,69 @@ public class IncomingSocketHandler {
         }
     }
     
+    /// create the writer source
+    private func createWriterSource() {
+        #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
+            writerSource = DispatchSource.makeWriteSource(fileDescriptor: socket.socketfd,
+                                                          queue: IncomingSocketHandler.socketWriterQueue)
+            
+            writerSource!.setEventHandler() {
+                self.handleWriteHelper()
+            }
+            writerSource!.setCancelHandler() {
+                self.writerSource = nil
+            }
+            writerSource!.resume()
+        #elseif GCD_ASYNCH
+            writerSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_WRITE, UInt(socket.socketfd), 0,
+                                                  IncomingSocketHandler.socketWriterQueue)
+            
+            dispatch_source_set_event_handler(writerSource!) {
+                self.handleWriteHelper()
+            }
+            dispatch_source_set_cancel_handler(writerSource!) {
+                self.writerSource = nil
+            }
+            dispatch_resume(writerSource!)
+        #endif
+    }
+    
     /// Write as much data to the socket as possible, buffering the rest
     func write(from data: Data) {
         guard socket.socketfd > -1  else { return }
         
-        do {
-            let written = try socket.write(from: data)
+        data.withUnsafeBytes() { [unowned self] (bytes: UnsafePointer<UInt8>) in
+            do {
+                let written: Int
             
-            if written != data.count {
-                lockWriteBufferLock()
-                writeBuffer.append(data.subdata(in: written..<data.count))
-                unlockWriteBufferLock()
+                if  self.writeBuffer.count == 0 {
+                    written = try self.socket.write(from: bytes, bufSize: data.count)
+                }
+                else {
+                    written = 0
+                }
+            
+                if written != data.count {
+                    let block = { [unowned self] in
+                        self.writeBuffer.append(bytes+written, count:data.count-written)
+                    }
+                    
+                    #if os(Linux)
+                        dispatch_sync(IncomingSocketHandler.socketWriterQueue, block)
+                    #else
+                        IncomingSocketHandler.socketWriterQueue.sync(execute: block)
+                    #endif
+                    
+                    #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
+                        if self.writerSource == nil {
+                            self.createWriterSource()
+                        }
+                    #endif
+                }
             }
-        }
-        catch {
-            Log.error("Write to socket (file descriptor \(socket.socketfd) failed. Error number=\(errno). Message=\(errorString(error: errno)).")
+            catch {
+                Log.error("Write to socket (file descriptor \(self.socket.socketfd) failed. Error number=\(errno). Message=\(self.errorString(error: errno)).")
+            }
         }
     }
     
@@ -199,10 +245,8 @@ public class IncomingSocketHandler {
     private func close() {
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
             readerSource.cancel()
-            writerSource.cancel()
         #elseif GCD_ASYNCH
-            dispatch_source_cancel(readerSource!)
-            dispatch_source_cancel(writerSource!)
+            dispatch_source_cancel(readerSource)
         #else
             handleCancel()
         #endif
@@ -215,22 +259,6 @@ public class IncomingSocketHandler {
         }
         processor?.inProgress = false
         processor?.keepAliveUntil = 0.0
-    }
-    
-    private func lockWriteBufferLock() {
-        #if os(Linux)
-            dispatch_semaphore_wait(writeBufferLock, DISPATCH_TIME_FOREVER)
-        #else
-            _ = writeBufferLock.wait(timeout: DispatchTime.distantFuture)
-        #endif
-    }
-    
-    private func unlockWriteBufferLock() {
-        #if os(Linux)
-            dispatch_semaphore_signal(writeBufferLock)
-        #else
-            writeBufferLock.signal()
-        #endif
     }
     
     /// Private method to return a string representation on a value of errno.

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -14,9 +14,7 @@
  * limitations under the License.
  **/
 
-#if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
-    import Dispatch
-#endif
+import Dispatch
 
 import Foundation
 

--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -125,7 +125,7 @@ class IncomingSocketManager  {
                                 handler.handleRead()
                             }
                             else {
-                                handlr.handleWrite()
+                                handler.handleWrite()
                             }
                         }
                         else {

--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -121,11 +121,12 @@ class IncomingSocketManager  {
                     }
                     else {
                         if  let handler = socketHandlers[event.data.fd] {
-                            if  (event.events & EPOLLIN.rawValue) == 1 {
-                                handler.handleRead()
-                            }
-                            else {
+    
+                            if  (event.events & EPOLLOUT.rawValue) != 0 {
                                 handler.handleWrite()
+                            }
+                            if  (event.events & EPOLLIN.rawValue) != 0 {
+                                handler.handleRead()
                             }
                         }
                         else {


### PR DESCRIPTION
Resolve the issue of being unable to send large payloads back to the client.

## Description
Add use of asynchronous socket writes to send the part of the output payload that doesn't get sent by the first write, which returns an errno of EAGAIN. EAGAIN is not an "error". It is simply an indication that one should try to send the rest later, when there is more room in the output buffer.
The new code uses epoll and DispatchSourceWrite on Linux and macOS, respectively, to determine when there is room in the output buffer. 

## Motivation and Context
Resolve issue IBM-Swift/Kitura#678

## How Has This Been Tested?
This has been tested by adding a test as well as by the originator of the issue in their setup.

## Checklist:

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
