### PR TITLE
Perf: increase max requests per keepalive connection

### DIFF
--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -49,7 +49,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     public var inProgress = true
     
     /// Number of remaining requests that will be allowed on the socket being handled by this handler
-    private(set) var numberOfRequests = 20
+    private(set) var numberOfRequests = 100
     
     /// Should this socket actually be kep alive?
     var isKeepAlive: Bool { return clientRequestedKeepAlive && numberOfRequests > 0 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Increased the max number of requests for a keepalive connection from 20 to 100.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This gives around a 5% performance improvement on Mac under common benchmark conditions (continuous load with a trivial operation such as returning 'Hello World').  Connections are relatively expensive to establish on Mac.
The number 100 was chosen as there was no measurable performance benefit in going higher, and this is also the default for Nginx.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran performance tests on Linux and Mac.  I evaluated various values from 20 (the existing value) up to 20,000.   20 -> 100 gains around 5% on Mac,  but there was no measurable benefit to increasing beyond this value.
There was negligible benefit on Linux, though this is not unexpected, as establishing new connections does not appear to have significant overhead.
I have not run any functional tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.