### PR TITLE
Resolve memory leak with keepalive connections (Kitura #655)

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -372,6 +372,11 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
             freeHTTPParser()
         }
     }
+    
+    /// Signal that the connection is being closed, and resources should be freed
+    func close() {
+        freeHTTPParser()
+    }
 
     /// Signal that reading is being reset
     func prepareToReset() {

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -98,6 +98,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     /// Close the socket and mark this handler as no longer in progress.
     public func close() {
         handler?.prepareToClose()
+        request.close()
     }
     
     /// Invoke the HTTP parser against the specified buffer of data and


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Kitura 0.23, support for HTTP keepalive was introduced.  While a connection is kept alive, the `HTTPParser` and associated C parser classes are reused for subsequent requests.  The `HTTPParser` and its delegate (the `HTTPIncomingMessage`) form a strong reference cycle.  This causes a leak in the case where the maximum number of keepalive requests is reached, as the process of closing the socket in this scenario neglected to invoke a method (`freeHTTPParser()`) intended to break the cycle.

See https://github.com/IBM-Swift/Kitura/issues/655

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves the leak caused by the `HTTPIncomingMessage <-> HTTPParser` reference cycle when keepalive is enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Performance benchmark run and memory leak no longer seen.
Kitura-net tests run + passing on OSX and Linux.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
