### PR TITLE
IBM/Kitura#692 Reset saveBody flag before reusing the request

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -381,6 +381,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     /// When we're ready, really reset everything
     private func reset() {
         lastHeaderWasAValue = false
+        saveBody = true
         url.count = 0
         headers.removeAll()
         bodyChunk.reset()


### PR DESCRIPTION
## Description
Keep alive reuses HTTPServerRequest objects. It wasn't reset completely.

## Motivation and Context
Fix issue IBM-Swift/Kitura#692

## How Has This Been Tested?
Test case supplied in the issue

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

