### PR TITLE
IBM-Swift/Kitura#682 Improve Kitura's performance

### DIFF
--- a/Sources/KituraNet/BufferList.swift
+++ b/Sources/KituraNet/BufferList.swift
@@ -18,12 +18,18 @@ import Foundation
 
 // MARK: BufferList 
 
+/// This class provides an implementation of a buffer that can be added to and
+/// "taken" from in chunks. Data is always added to the end of the buffer and
+/// data is "taken" from the buffer from the beginning towards the end. A pointer
+/// is maintained as where the next chunk of data will be "taken" from. This
+/// pointer can be reset, to enable the data in the buffer to be fetched from the
+/// beginning again.
 public class BufferList {
 
     // MARK: -- Private 
     
     /// Internal storage buffer
-    private let localData = NSMutableData()
+    private let localData = NSMutableData(capacity: 4096) ?? NSMutableData()
     
     /// Byte offset inside of internal storage buffer
     private var byteIndex = 0
@@ -64,16 +70,12 @@ public class BufferList {
     ///
     /// - Parameter array: a [UInt8] for the data you want from the buffer
     ///
-    /// - Returns:
+    /// - Returns: The number of bytes actually copied from the buffer. It will be the
+    ///           lessor of the number of bytes left in the buffer and the length
+    ///           of the array.
     public func fill(array: inout [UInt8]) -> Int {
         
-        let result = min(array.count, localData.length - byteIndex)
-        let bytes = localData.bytes.assumingMemoryBound(to: UInt8.self) + byteIndex
-        UnsafeMutableRawPointer(mutating: array).copyBytes(from: bytes, count: result)
-        byteIndex += result
-        
-        return result
-        
+        return fill(buffer: UnsafeMutablePointer(mutating: array), length: array.count)
     }
     
     /// Fill memory with data from the buffer
@@ -81,7 +83,9 @@ public class BufferList {
     /// - Parameter buffer: NSMutablePointer to the beginning of the memory to be filled
     /// - Parameter length: The number of bytes to fill
     ///
-    /// - Returns:
+    /// - Returns: The number of bytes actually copied from the buffer. It will be the
+    ///           lessor of the number of bytes left in the buffer and the length
+    ///           of the memory area provided.
     public func fill(buffer: UnsafeMutablePointer<UInt8>, length: Int) -> Int {
         
         let result = min(length, localData.length - byteIndex)
@@ -97,7 +101,8 @@ public class BufferList {
     ///
     /// - Parameter data: The Data struct to fill from data in the buffer
     ///
-    /// - Returns:
+    /// - Returns: The number of bytes actually copied from the buffer. It will be equal
+    ///           to the number of bytes lect in the buffer.
     public func fill(data: inout Data) -> Int {
         
         let result = localData.length - byteIndex
@@ -111,7 +116,8 @@ public class BufferList {
     ///
     /// - Parameter data: The NSMutableData object to fill from data in the buffer
     ///
-    /// - Returns:
+    /// - Returns: The number of bytes actually copied from the buffer. It will be equal
+    ///           to the number of bytes lect in the buffer.
     public func fill(data: NSMutableData) -> Int {
         
         let result = localData.length - byteIndex
@@ -129,7 +135,8 @@ public class BufferList {
         
     }
     
-    /// Sets the buffer back to the beginning position
+    /// Sets the buffer back to the beginning position, the next fill call will take data
+    /// from the beginning of the buffer.
     public func rewind() {
         
         byteIndex = 0

--- a/Sources/KituraNet/BufferList.swift
+++ b/Sources/KituraNet/BufferList.swift
@@ -22,67 +22,53 @@ public class BufferList {
 
     // MARK: -- Private 
     
-    ///
     /// Internal storage buffer
-    ///
-    private let localData = NSMutableData(capacity: 4096)!
+    private let localData = NSMutableData()
     
-    ///
     /// Byte offset inside of internal storage buffer
     private var byteIndex = 0
     
     // MARK: -- Public 
     
-    ///
     /// Get the number of bytes stored in the BufferList
     public var count: Int {
         return localData.length
     }
     
-    ///
     /// Read the data in the BufferList
-    ///
     public var data: Data {
         return Data(bytes: localData.bytes, count: localData.length)
     }
     
-    ///
     /// Initializes a BufferList instance
     ///
     /// - Returns: a BufferList instance
-    ///
     public init() {}
     
-    /// 
-    /// Append bytes in an array to buffer 
+    /// Append bytes to the buffer
     ///
-    /// Parameter bytes: a pointer to the array
-    /// Parameter length: number of bytes in the array
-    ///
+    /// Parameter bytes: The pointer to the bytes
+    /// Parameter length: The number of bytes to append
     public func append(bytes: UnsafePointer<UInt8>, length: Int) {
         localData.append(bytes, length: length)
     }
     
-    ///
     /// Append data into BufferList 
     /// 
     /// Parameter data: The data to append
-    ///
     public func append(data: Data) {
         localData.append(data)
     }
     
+    /// Fill an array with data from the buffer
     ///
-    /// Fill the buffer with a byte array data
-    ///
-    /// - Parameter buffer: a [UInt8] for data you want in the buffer
+    /// - Parameter array: a [UInt8] for the data you want from the buffer
     ///
     /// - Returns:
-    ///
     public func fill(array: inout [UInt8]) -> Int {
         
-        let result = min(array.count, localData.length-byteIndex)
-        let bytes = localData.bytes.assumingMemoryBound(to: UInt8.self)+byteIndex
+        let result = min(array.count, localData.length - byteIndex)
+        let bytes = localData.bytes.assumingMemoryBound(to: UInt8.self) + byteIndex
         UnsafeMutableRawPointer(mutating: array).copyBytes(from: bytes, count: result)
         byteIndex += result
         
@@ -90,18 +76,16 @@ public class BufferList {
         
     }
     
+    /// Fill memory with data from the buffer
     ///
-    /// Fill the buffer with a byte array data
-    ///
-    /// - Parameter buffer: NSMutablePointer to the beginning of the array
-    /// - Parameter length: the number of bytes in the array
+    /// - Parameter buffer: NSMutablePointer to the beginning of the memory to be filled
+    /// - Parameter length: The number of bytes to fill
     ///
     /// - Returns:
-    ///
     public func fill(buffer: UnsafeMutablePointer<UInt8>, length: Int) -> Int {
         
-        let result = min(length, localData.length-byteIndex)
-        let bytes = localData.bytes.assumingMemoryBound(to: UInt8.self)+byteIndex
+        let result = min(length, localData.length - byteIndex)
+        let bytes = localData.bytes.assumingMemoryBound(to: UInt8.self) + byteIndex
         UnsafeMutableRawPointer(buffer).copyBytes(from: bytes, count: result)
         byteIndex += result
         
@@ -109,41 +93,35 @@ public class BufferList {
         
     }
     
+    /// Fill a Data struct with data from the buffer
     ///
-    /// Fill the buffer with data 
-    ///
-    /// - Parameter data: Data you want in the buffer
-    ///
-    /// - Returns: 
-    ///
-    public func fill(data: inout Data) -> Int {
-        
-        let result = localData.length-byteIndex
-        data.append(localData.bytes.assumingMemoryBound(to: UInt8.self)+byteIndex, count: result)
-        byteIndex += result
-        return result
-        
-    }
-    
-    ///
-    /// Fill the buffer with data
-    ///
-    /// - Parameter data: NSMutableData you want in the buffer
+    /// - Parameter data: The Data struct to fill from data in the buffer
     ///
     /// - Returns:
-    ///
-    public func fill(data: NSMutableData) -> Int {
+    public func fill(data: inout Data) -> Int {
         
-        let result = localData.length-byteIndex
-        data.append(localData.bytes.assumingMemoryBound(to: UInt8.self)+byteIndex, length: result)
+        let result = localData.length - byteIndex
+        data.append(localData.bytes.assumingMemoryBound(to: UInt8.self) + byteIndex, count: result)
         byteIndex += result
         return result
         
     }
     
+    /// Fill an NSMutableData with data from the buffer
     ///
+    /// - Parameter data: The NSMutableData object to fill from data in the buffer
+    ///
+    /// - Returns:
+    public func fill(data: NSMutableData) -> Int {
+        
+        let result = localData.length - byteIndex
+        data.append(localData.bytes.assumingMemoryBound(to: UInt8.self) + byteIndex, length: result)
+        byteIndex += result
+        return result
+        
+    }
+    
     /// Resets the buffer to zero length and the beginning position
-    ///
     public func reset() {
         
         localData.length = 0
@@ -151,9 +129,7 @@ public class BufferList {
         
     }
     
-    ///
     /// Sets the buffer back to the beginning position
-    ///
     public func rewind() {
         
         byteIndex = 0

--- a/Sources/KituraNet/ClientResponse.swift
+++ b/Sources/KituraNet/ClientResponse.swift
@@ -48,8 +48,8 @@ public class ClientResponse: HTTPIncomingMessage {
     
     /// Parse the contents of the responseBuffers
     func parse() -> HTTPParserStatus {
-        var buffer = Data()
-        _ = responseBuffers.fill(data: &buffer)
+        let buffer = NSMutableData()
+        _ = responseBuffers.fill(data: buffer)
         return super.parse(buffer)
     }
 }

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -53,10 +53,10 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     private var lastHeaderWasAValue = false
 
     /// Bytes of a header key that was just parsed and returned in chunks by the pars
-    private var lastHeaderField = Data()
+    private let lastHeaderField = NSMutableData()
 
     /// Bytes of a header value that was just parsed and returned in chunks by the parser
-    private var lastHeaderValue = Data()
+    private let lastHeaderValue = NSMutableData()
 
     /// The http_parser Swift wrapper
     private var httpParser: HTTPParser?
@@ -101,14 +101,14 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     
     /// Parse the message
     ///
-    /// - Parameter callback: (HTTPParserStatus) -> Void closure
-    func parse (_ buffer: Data) -> HTTPParserStatus {
+    /// - Parameter buffer: An NSData object contaning the data to be parsed
+    func parse (_ buffer: NSData) -> HTTPParserStatus {
         guard let parser = httpParser else {
             status.error = .internalError
             return status
         }
         
-        var length = buffer.count
+        var length = buffer.length
         
         guard length > 0  else {
             /* Handle unexpected EOF. Usually just close the connection. */
@@ -124,27 +124,25 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         
         var start = 0
         while status.state == .initial  &&  status.error == nil  &&  length > 0  {
-            
-            buffer.withUnsafeBytes() { [unowned self] (bytes: UnsafePointer<Int8>) in
-                let (numberParsed, upgrade) = parser.execute(bytes+start, length: length)
-                if upgrade == 1 {
-                    // TODO handle new protocol
-                }
-                else if  numberParsed != length  {
-                
-                    if  self.status.state == .reset  {
-                        // Apparently the short message was a Continue. Let's just keep on parsing
-                        start = numberParsed
-                        self.reset()
-                    }
-                    else {
-                        /* Handle error. Usually just close the connection. */
-                        self.freeHTTPParser()
-                        self.status.error = .parsedLessThanRead
-                    }
-                }
-                length -= numberParsed
+            let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self)+start
+            let (numberParsed, upgrade) = parser.execute(bytes, length: length)
+            if upgrade == 1 {
+                // TODO handle new protocol
             }
+            else if  numberParsed != length  {
+                
+                if  self.status.state == .reset  {
+                    // Apparently the short message was a Continue. Let's just keep on parsing
+                    start = numberParsed
+                    self.reset()
+                }
+                else {
+                    /* Handle error. Usually just close the connection. */
+                    self.freeHTTPParser()
+                    self.status.error = .parsedLessThanRead
+                }
+            }
+            length -= numberParsed
         }
         
         return status
@@ -267,20 +265,22 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
 
     /// Instructions for when reading URL portion
     ///
-    /// - Parameter data: the data
-    func onURL(_ data: Data) {
-        url.append(data)
+    /// - Parameter bytes: The bytes of the parsed URL
+    /// - Parameter count: The number of bytes parsed
+    func onURL(_ bytes: UnsafePointer<UInt8>, count: Int) {
+        url.append(bytes, count: count)
     }
 
-    /// Instructions for when reading header field
+    /// Instructions for when reading header key
     ///
-    /// - Parameter data: the data
-    func onHeaderField (_ data: Data) {
+    /// - Parameter bytes: The bytes of the parsed header key
+    /// - Parameter count: The number of bytes parsed
+    func onHeaderField (_ bytes: UnsafePointer<UInt8>, count: Int) {
         
         if lastHeaderWasAValue {
             addHeader()
         }
-        lastHeaderField.append(data)
+        lastHeaderField.append(bytes, length: count)
 
         lastHeaderWasAValue = false
         
@@ -288,9 +288,10 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
 
     /// Instructions for when reading a header value
     ///
-    /// - Parameter data: the data
-    func onHeaderValue (_ data: Data) {
-        lastHeaderValue.append(data)
+    /// - Parameter bytes: The bytes of the parsed header value
+    /// - Parameter count: The number of bytes parsed
+    func onHeaderValue (_ bytes: UnsafePointer<UInt8>, count: Int) {
+        lastHeaderValue.append(bytes, length: count)
 
         lastHeaderWasAValue = true
     }
@@ -298,35 +299,24 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     /// Set the header key-value pair
     private func addHeader() {
 
-        let headerKey = StringUtils.fromUtf8String(lastHeaderField)!
-        let headerValue = StringUtils.fromUtf8String(lastHeaderValue)!
+        let nsHeaderKey = NSString(bytes: lastHeaderField.bytes, length: lastHeaderField.length, encoding: String.Encoding.utf8.rawValue)!
+        let headerKey = String(describing: nsHeaderKey)
+        let nsHeaderValue = NSString(bytes: lastHeaderValue.bytes, length: lastHeaderValue.length, encoding: String.Encoding.utf8.rawValue)!
+        let headerValue = String(describing: nsHeaderValue)
         
-        switch(headerKey.lowercased()) {
-            // Headers with a simple value that are not merged (i.e. duplicates dropped)
-            // https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
-            //
-            case "content-type", "content-length", "user-agent", "referer", "host",
-                 "authorization", "proxy-authorization", "if-modified-since",
-                 "if-unmodified-since", "from", "location", "max-forwards",
-                 "retry-after", "etag", "last-modified", "server", "age", "expires":
-                if let _ = headers[headerKey] {
-                    break
-                }
-                fallthrough
-            default:
-                headers.append(headerKey, value: headerValue)
-        }
+        headers.append(headerKey, value: headerValue)
 
-        lastHeaderField.count = 0
-        lastHeaderValue.count = 0
+        lastHeaderField.length = 0
+        lastHeaderValue.length = 0
 
     }
 
     /// Instructions for when reading the body of the message
     ///
-    /// - Parameter data: the data
-    func onBody (_ data: Data) {
-        self.bodyChunk.append(data: data)
+    /// - Parameter bytes: The bytes of the parsed body
+    /// - Parameter count: The number of bytes parsed
+    func onBody (_ bytes: UnsafePointer<UInt8>, count: Int) {
+        self.bodyChunk.append(bytes: bytes, length: count)
 
     }
 

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -124,7 +124,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         
         var start = 0
         while status.state == .initial  &&  status.error == nil  &&  length > 0  {
-            let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self)+start
+            let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self) + start
             let (numberParsed, upgrade) = parser.execute(bytes, length: length)
             if upgrade == 1 {
                 // TODO handle new protocol

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -72,7 +72,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     
     /// Process data read from the socket. It is either passed to the HTTP parser or
     /// it is saved in the Pseudo synchronous reader to be read later on.
-    public func process(_ buffer: Data) {
+    public func process(_ buffer: NSData) {
         switch(state) {
         case .reset:
             request.prepareToReset()
@@ -103,7 +103,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     
     /// Invoke the HTTP parser against the specified buffer of data and
     /// convert the HTTP parser's status to our own.
-    private func parse(_ buffer: Data) {
+    private func parse(_ buffer: NSData) {
         let parsingStatus = request.parse(buffer)
         guard  parsingStatus.error == nil  else  {
             Log.error("Failed to parse a request. \(parsingStatus.error!)")

--- a/Sources/KituraNet/HTTPParser/HTTPParser.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParser.swift
@@ -73,28 +73,28 @@ class HTTPParser {
         settings = http_parser_settings()
         
         settings.on_url = { (parser, chunk, length) -> Int32 in
-            let data = Data(bytes: chunk!, count: length)
-            getDelegate(parser)?.onURL(data)
+            let ptr = UnsafeRawPointer(chunk!).assumingMemoryBound(to: UInt8.self)
+            getDelegate(parser)?.onURL(ptr, count: length)
             return 0
         }
         
         settings.on_header_field = { (parser, chunk, length) -> Int32 in
-            let data = Data(bytes: chunk!, count: length)
-            getDelegate(parser)?.onHeaderField(data)
+            let ptr = UnsafeRawPointer(chunk!).assumingMemoryBound(to: UInt8.self)
+            getDelegate(parser)?.onHeaderField(ptr, count: length)
             return 0
         }
         
         settings.on_header_value = { (parser, chunk, length) -> Int32 in
-            let data = Data(bytes: chunk!, count: length)
-            getDelegate(parser)?.onHeaderValue(data)
+            let ptr = UnsafeRawPointer(chunk!).assumingMemoryBound(to: UInt8.self)
+            getDelegate(parser)?.onHeaderValue(ptr, count: length)
             return 0
         }
         
         settings.on_body = { (parser, chunk, length) -> Int32 in
             let delegate = getDelegate(parser)
             if delegate?.saveBody == true {
-                let data = Data(bytes: chunk!, count: length)
-                delegate?.onBody(data)
+                let ptr = UnsafeRawPointer(chunk!).assumingMemoryBound(to: UInt8.self)
+                delegate?.onBody(ptr, count: length)
             }
             return 0
         }
@@ -176,12 +176,12 @@ fileprivate func getDelegate(_ parser: UnsafeMutableRawPointer?) -> HTTPParserDe
 ///
 protocol HTTPParserDelegate: class {
     var saveBody : Bool { get }
-    func onURL(_ url: Data)
-    func onHeaderField(_ data: Data)
-    func onHeaderValue(_ data: Data)
+    func onURL(_ url: UnsafePointer<UInt8>, count: Int)
+    func onHeaderField(_ bytes: UnsafePointer<UInt8>, count: Int)
+    func onHeaderValue(_ bytes: UnsafePointer<UInt8>, count: Int)
     func onHeadersComplete(method: String, versionMajor: UInt16, versionMinor: UInt16)
     func onMessageBegin()
     func onMessageComplete()
-    func onBody(_ body: Data)
+    func onBody(_ bytes: UnsafePointer<UInt8>, count: Int)
     func prepareToReset()    
 }

--- a/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
@@ -39,7 +39,7 @@ extension HTTPParserErrorType: CustomStringConvertible {
         case .internalError:
             return "An internal error occurred"
         case .parsedLessThanRead:
-            return "Parsed less bytes than were passed to the HTTP parser"
+            return "Parsed fewer bytes than were passed to the HTTP parser"
         case .unexpectedEOF:
             return "Unexpectedly got an EOF when reading the request"
         }

--- a/Sources/KituraNet/HeadersContainer.swift
+++ b/Sources/KituraNet/HeadersContainer.swift
@@ -18,14 +18,10 @@ import Foundation
 
 public class HeadersContainer {
     
-    ///
     /// The header storage
-    ///
     internal var headers: [String: [String]] = [:]
     
-    ///
     /// The map of case insensitive header fields to their actual names
-    ///
     private var caseInsensitiveMap: [String: String] = [:]
     
     public subscript(key: String) -> [String]? {
@@ -43,30 +39,41 @@ public class HeadersContainer {
         }
     }
     
-    ///
     /// Append values to the header
     ///
     /// - Parameter key: the key
     /// - Parameter value: the value
-    ///
     public func append(_ key: String, value: [String]) {
         
+        let lowerCaseKey = key.lowercased()
+        
         // Determine how to handle the header (append or merge)
-        switch(key.lowercased()) {
+        switch(lowerCaseKey) {
             
         // Headers with an array value (can appear multiple times, but can't be merged)
         case "set-cookie":
-            if let headerKey = caseInsensitiveMap[key.lowercased()] {
+            if let headerKey = caseInsensitiveMap[lowerCaseKey] {
                 headers[headerKey]? += value
             } else {
-                set(key, value: value)
+                set(key, lowerCaseKey: lowerCaseKey, value: value)
             }
             
+        // Headers with a simple value that are not merged (i.e. duplicates dropped)
+        // https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
+        //
+        case "content-type", "content-length", "user-agent", "referer", "host",
+             "authorization", "proxy-authorization", "if-modified-since",
+             "if-unmodified-since", "from", "location", "max-forwards",
+             "retry-after", "etag", "last-modified", "server", "age", "expires":
+            if let _ = caseInsensitiveMap[lowerCaseKey] {
+                break
+            }
+            fallthrough
             
         // Headers with a simple value that can be merged
         default:
-            guard let headerKey = caseInsensitiveMap[key.lowercased()], let oldValue = headers[headerKey]?.first else {
-                set(key, value: value)
+            guard let headerKey = caseInsensitiveMap[lowerCaseKey], let oldValue = headers[headerKey]?.first else {
+                set(key, lowerCaseKey: lowerCaseKey, value: value)
                 return
             }
             let newValue = oldValue + ", " + value.joined(separator: ", ")
@@ -74,24 +81,20 @@ public class HeadersContainer {
         }
     }
     
-    ///
     /// Append values to the header
     ///
     /// - Parameter key: the key
     /// - Parameter value: the value
-    ///
     public func append(_ key: String, value: String) {
 
         append(key, value: [value])
     }
 
-    ///
     /// Gets the header (case insensitive)
     ///
     /// - Parameter key: the key
     ///
     /// - Returns: the value for the key
-    ///
     private func get(_ key: String) -> [String]? {
         if let headerKey = caseInsensitiveMap[key.lowercased()] {
             return headers[headerKey]
@@ -100,33 +103,32 @@ public class HeadersContainer {
         return nil
     }
     
-    ///
     /// Remove all of the headers
-    ///
     func removeAll() {
         headers.removeAll(keepingCapacity: true)
         caseInsensitiveMap.removeAll(keepingCapacity: true)
     }
     
-    ///
     /// Set the header value
     ///
     /// - Parameter key: the key
     /// - Parameter value: the value
-    ///
-    /// - Returns: the value for the key as a list
-    ///
     private func set(_ key: String, value: [String]) {
-        
+        set(key, lowerCaseKey: key.lowercased(), value: value)
+    }
+    
+    /// Set the header value
+    ///
+    /// - Parameter key: the key
+    /// - Parameter value: the value
+    private func set(_ key: String, lowerCaseKey: String, value: [String]) {
         headers[key] = value
         caseInsensitiveMap[key.lowercased()] = key
     }
     
-    ///
     /// Remove the header by key (case insensitive)
     ///
     /// - Parameter key: the key
-    ///
     private func remove(_ key: String) {
         
         if let headerKey = caseInsensitiveMap[key.lowercased()] {

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -74,14 +74,14 @@ public class IncomingSocketHandler {
     
     /// Read in the available data and hand off to common processing code
     func handleRead() {
-        var buffer = Data()
+        let buffer = NSMutableData()
         
         do {
             var length = 1
             while  length > 0  {
-                length = try socket.read(into: &buffer)
+                length = try socket.read(into: buffer)
             }
-            if  buffer.count > 0  {
+            if  buffer.length > 0  {
                 processor?.process(buffer)
             }
             else {

--- a/Sources/KituraNet/IncomingSocketProcessor.swift
+++ b/Sources/KituraNet/IncomingSocketProcessor.swift
@@ -33,7 +33,7 @@ public protocol IncomingSocketProcessor: class {
 
     /// Process data read from the socket. It is either passed to the HTTP parser or
     /// it is saved in the Pseudo synchronous reader to be read later on.
-    func process(_ buffer: Data)
+    func process(_ buffer: NSData)
     
     /// Write data to the socket
     func write(from data: Data)


### PR DESCRIPTION
## Description
Improve Kitura's performance by:

  - Using NSData and NSMutableData instead of Data in several internal places
  - Passing UnsafeRawPointer and length pair from the parsing code to the HTTPIncomingMessage class instead of using a temporary Data struct
  - Minimizing the number of times a header key is lower cased when parsing a request

## Motivation and Context
Improving Kitura's performance

## How Has This Been Tested?
Tested using Kitura-net's tests and the TechEmpower tests

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

