### PR TITLE
Faster http date construction in SPIUtils

### DIFF
--- a/Sources/KituraNet/SPIUtils.swift
+++ b/Sources/KituraNet/SPIUtils.swift
@@ -52,10 +52,26 @@ public class SPIUtils {
         let wday = Int(timeStruct.tm_wday)
         let mday = Int(timeStruct.tm_mday)
         let mon = Int(timeStruct.tm_mon)
+        let year = Int(timeStruct.tm_year) + 1900
         let hour = Int(timeStruct.tm_hour)
         let min = Int(timeStruct.tm_min)
         let sec = Int(timeStruct.tm_sec)
-        return "\(days[wday]), \(twoDigit(mday)) \(months[mon]) \(timeStruct.tm_year+1900) \(twoDigit(hour)):\(twoDigit(min)):\(twoDigit(sec)) GMT"
+        var s = days[wday]
+        s.append(", ")
+        s.append(twoDigit[mday])
+        s.append(" ")
+        s.append(months[mon])
+        s.append(" ")
+        s.append(twoDigit[year/100])
+        s.append(twoDigit[year%100])
+        s.append(" ")
+        s.append(twoDigit[hour])
+        s.append(":")
+        s.append(twoDigit[min])
+        s.append(":")
+        s.append(twoDigit[sec])
+        s.append(" GMT")
+        return s
         
     }
     
@@ -77,17 +93,20 @@ public class SPIUtils {
         let hour = Int(components.hour!)
         let min = Int(components.minute!)
         let sec = Int(components.second!)
-        return "\(days[wday-1]), \(twoDigit(mday)) \(months[mon-1]) \(year) \(twoDigit(hour)):\(twoDigit(min)):\(twoDigit(sec)) GMT"
+        return "\(days[wday-1]), \(twoDigit[mday]) \(months[mon-1]) \(year) \(twoDigit[hour]):\(twoDigit[min]):\(twoDigit[sec]) GMT"
     }
 
     ///
-    /// Prepends a zero to a 2 digit number if necessary
+    /// Fast Int to String conversion
     ///
-    /// - Parameter num: the number
-    ///
-    private static func twoDigit(_ num: Int) -> String {
-
-        return (num < 10 ? "0" : "") + String(num)
-
-    }
+    private static let twoDigit = ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+                                   "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+                                   "20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+                                   "30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
+                                   "40", "41", "42", "43", "44", "45", "46", "47", "48", "49",
+                                   "50", "51", "52", "53", "54", "55", "56", "57", "58", "59",
+                                   "60", "61", "62", "63", "64", "65", "66", "67", "68", "69",
+                                   "70", "71", "72", "73", "74", "75", "76", "77", "78", "79",
+                                   "80", "81", "82", "83", "84", "85", "86", "87", "88", "89",
+                                   "90", "91", "92", "93", "94", "95", "96", "97", "98", "99"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This patch avoids constructing temporary strings and string interpolation.

## Motivation and Context

Improving Kitura's performance.

## How Has This Been Tested?

Performance measured on OSX using attached benchmarks:
current.swift: 2.9s
proposed.swift: 0.9s
[tests.zip](https://github.com/IBM-Swift/Kitura-net/files/449684/tests.zip)

Passed Kitura-net tests on OSX.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

