### PR TITLE
Alternate between two socket reader queues for better performance on OSX

### DIFF
--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -36,7 +36,7 @@ public class IncomingSocketHandler {
     static let socketWriterQueue = DispatchQueue(label: "Socket Writer")
     
     #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
-        static let socketReaderQueue = DispatchQueue(label: "Socket Reader")
+        static let socketReaderQueue = [DispatchQueue(label: "Socket Reader A"), DispatchQueue(label: "Socket Reader B")]
     
         // Note: This var is optional to enable it to be constructed in the init function
         var readerSource: DispatchSourceRead!
@@ -58,7 +58,7 @@ public class IncomingSocketHandler {
         
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
             readerSource = DispatchSource.makeReadSource(fileDescriptor: socket.socketfd,
-                                                         queue: IncomingSocketHandler.socketReaderQueue)
+                                                         queue: IncomingSocketHandler.socketReaderQueue[Int(socket.socketfd%2)])
         
             readerSource.setEventHandler() {
                 self.handleRead()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improve Kitura's performance on OSX by using two serial socket reader queues instead of one.

The performance with a 4-core system seems unaffected. There is a significant increase in performance with systems with 6 or 8 cores (up to 40%). There is no clear benefit to having more than 2 queues.

## Motivation and Context

Improving Kitura's performance.

## How Has This Been Tested?

Performance measured using TechEmpower benchmark.
Tested using Kitura-net's tests on OSX.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

