### PR TITLE
IBM-Swift/Kitura#718 Added tests for Content-Type header

### DIFF
--- a/Sources/KituraNet/HeadersContainer.swift
+++ b/Sources/KituraNet/HeadersContainer.swift
@@ -16,6 +16,8 @@
 
 import Foundation
 
+import LoggerAPI
+
 public class HeadersContainer {
     
     /// The header storage
@@ -59,13 +61,14 @@ public class HeadersContainer {
             }
             
         // Headers with a simple value that are not merged (i.e. duplicates dropped)
-        // https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
+        // https://dxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp#252
         //
         case "content-type", "content-length", "user-agent", "referer", "host",
              "authorization", "proxy-authorization", "if-modified-since",
              "if-unmodified-since", "from", "location", "max-forwards",
              "retry-after", "etag", "last-modified", "server", "age", "expires":
             if let _ = caseInsensitiveMap[lowerCaseKey] {
+                Log.warning("Duplicate header \(key) discarded")
                 break
             }
             fallthrough

--- a/Tests/KituraNetTests/HTTPResponseTests.swift
+++ b/Tests/KituraNetTests/HTTPResponseTests.swift
@@ -1,0 +1,61 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import XCTest
+
+@testable import KituraNet
+
+class HTTPResponseTests: XCTestCase {
+    static var allTests : [(String, (HTTPResponseTests) -> () throws -> Void)] {
+        return [
+            ("testContentTypeHeaders", testContentTypeHeaders)
+        ]
+    }
+    
+    func testContentTypeHeaders() {
+        let headers = HeadersContainer()
+        
+        headers.append("Content-Type", value: "text/html")
+        var values = headers["Content-Type"]
+        XCTAssertNotNil(values, "Couldn't retrieve just set Content-Type header")
+        XCTAssertEqual(values!.count, 1, "Content-Type header should only have one value")
+        XCTAssertEqual(values![0], "text/html")
+        
+        headers.append("Content-Type", value: "text/plain; charset=utf-8")
+        XCTAssertEqual(headers["Content-Type"]![0], "text/html")
+        
+        headers["Content-Type"] = nil
+        XCTAssertNil(headers["Content-Type"])
+        
+        headers.append("Content-Type", value: "text/plain, image/png")
+        XCTAssertEqual(headers["Content-Type"]![0], "text/plain, image/png")
+        
+        headers.append("Content-Type", value: "text/html, image/jpeg")
+        XCTAssertEqual(headers["Content-Type"]![0], "text/plain, image/png")
+        
+        headers.append("Content-Type", value: "charset=UTF-8")
+        XCTAssertEqual(headers["Content-Type"]![0], "text/plain, image/png")
+        
+        headers["Content-Type"] = nil
+        
+        headers.append("Content-Type", value: "text/html")
+        XCTAssertEqual(headers["Content-Type"]![0], "text/html")
+        
+        headers.append("Content-Type", value: "image/png, text/plain")
+        XCTAssertEqual(headers["Content-Type"]![0], "text/html")
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -21,6 +21,7 @@ import XCTest
 XCTMain([
        testCase(ClientE2ETests.allTests),
        testCase(ClientRequestTests.allTests),
+       testCase(HTTPResponseTests.allTests),
        testCase(LargePayloadTests.allTests),
        testCase(ParserTests.allTests),
        testCase(FastCGIProtocolTests.allTests)


### PR DESCRIPTION
Added tests for Server side Headers
## Description
Added tests for server side adding and deleting Content-Type headers. Insuring that additional ones are discarded.

## Motivation and Context
Code coverage.

## How Has This Been Tested?
Ran swift test on both Linux and OSX

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

