### PR TITLE
Avoid leaking HTTPParser from a ClientRequest error path

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -274,6 +274,9 @@ public class ClientRequest {
     ///
     /// - Parameter close: add the "Connection: close" header
     public func end(close: Bool = false) {
+        defer {
+          response.close()
+        }
 
         closeConnection = close
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This avoids a memory leak where a pair of HTTPIncomingMessage and HTTPParser objects are left with a strong reference cycle when a ClientRequest is unsuccessful (curl returns an error, or unable to parse the response).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partial fix for Kitura #548 (Memory leak when executing HTTP.request)
- there is still a leak that is somehow related to the headers passed to CCurl, which will be addressed in a future PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the Kitura-net tests on Linux and Mac, and a simple testcase for demonstrating the leak.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

