### PR TITLE
Migrate from our own concurrent queues to using the Global Queue

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -22,14 +22,6 @@ import LoggerAPI
 /// A server that listens for incoming HTTP requests that are sent using the FastCGI
 /// protocol.
 public class FastCGIServer {
- 
-    /// Queue for listening and establishing new connections
-    private static var listenerQueue = DispatchQueue(label: "FastCGIServer.listenerQueue",
-                                                     attributes: [DispatchQueue.Attributes.concurrent])
-
-    /// Queue for handling client requests
-    private static var clientHandlerQueue = DispatchQueue(label: "FastCGIServer.clientHandlerQueue",
-                                                          attributes: [DispatchQueue.Attributes.concurrent])
 
     /// The `ServerDelegate` to handle incoming requests.
     public weak var delegate: ServerDelegate?
@@ -78,7 +70,7 @@ public class FastCGIServer {
             }
         })
 
-        ListenerGroup.enqueueAsynchronously(on: FastCGIServer.listenerQueue, block: queuedBlock)
+        ListenerGroup.enqueueAsynchronously(on: DispatchQueue.global(), block: queuedBlock)
         
     }
     
@@ -154,7 +146,7 @@ public class FastCGIServer {
             return
         }
         
-        FastCGIServer.clientHandlerQueue.async() {
+        DispatchQueue.global().async() {
             
             let request = FastCGIServerRequest(socket: clientSocket)
             let response = FastCGIServerResponse(socket: clientSocket, request: request)

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -24,12 +24,6 @@ import Socket
 /// An HTTP server that listens for connections on a socket.
 public class HTTPServer {
 
-    /// Queue for listening and establishing new connections.
-    private static let listenerQueue = DispatchQueue(label: "HTTPServer.listenerQueue", attributes: [DispatchQueue.Attributes.concurrent])
-
-    /// Queue for handling client requests
-    static let clientHandlerQueue = DispatchQueue(label: "HTTPServer.clientHandlerQueue", attributes: [DispatchQueue.Attributes.concurrent])
-
     /// HTTP `ServerDelegate`.
     public weak var delegate: ServerDelegate?
     
@@ -84,7 +78,7 @@ public class HTTPServer {
             }
         })
 
-        ListenerGroup.enqueueAsynchronously(on: HTTPServer.listenerQueue, block: queuedBlock)
+        ListenerGroup.enqueueAsynchronously(on: DispatchQueue.global(), block: queuedBlock)
     }
 
     /// Stop listening for new connections.

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -15,6 +15,7 @@
  */
 
 import Foundation
+import Dispatch
 
 import LoggerAPI
 import Socket
@@ -85,7 +86,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
             
         case .initial:
             inProgress = true
-            HTTPServer.clientHandlerQueue.async() { [unowned self] in
+            DispatchQueue.global().async() { [unowned self] in
                 self.parse(buffer)
             }
             


### PR DESCRIPTION
## Description
Remove KituraNet's own locally created concurrent queues and use the Dispatch provided Global Queue instead.

## Motivation and Context
The performance guys claimed we are better off having fewer queues.

## How Has This Been Tested?
Ran swift test and TechEmpower test

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
