### PR TITLE
Fixed memory leak in ClientResponse in error situations.

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -108,7 +108,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         
         guard length > 0  else {
             /* Handle unexpected EOF. Usually just close the connection. */
-            freeHTTPParser()
+            release()
             status.error = .unexpectedEOF
             return status
         }
@@ -134,7 +134,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                 }
                 else {
                     /* Handle error. Usually just close the connection. */
-                    self.freeHTTPParser()
+                    self.release()
                     self.status.error = .parsedLessThanRead
                 }
             }
@@ -166,7 +166,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                         }
                         else if (numberParsed != count) {
                             /* Handle error. Usually just close the connection. */
-                            self.freeHTTPParser()
+                            self.release()
                             self.status.error = .parsedLessThanRead
                         }
                         else {
@@ -179,7 +179,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                 }
                 catch let error {
                     /* Handle error. Usually just close the connection. */
-                    freeHTTPParser()
+                    release()
                     status.error = .internalError
                     throw error
                 }
@@ -217,7 +217,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                         ioBuffer.withUnsafeBytes() { [unowned self] (bytes: UnsafePointer<Int8>) in
                             let (numberParsed, _) = parser.execute(bytes, length: count)
                             if (numberParsed != count) {
-                                self.freeHTTPParser()
+                                self.release()
                                 self.status.error = .parsedLessThanRead
                             }
                         }
@@ -227,7 +227,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                     }
                 }
                 catch {
-                    freeHTTPParser()
+                    release()
                     status.error = .internalError
                 }
             }
@@ -343,12 +343,12 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         status.keepAlive = httpParser?.isKeepAlive() ?? false
         status.state = .messageComplete
         if  !status.keepAlive  {
-            freeHTTPParser()
+            release()
         }
     }
     
     /// Signal that the connection is being closed, and resources should be freed
-    func close() {
+    func release() {
         freeHTTPParser()
     }
 

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -105,7 +105,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     /// Close the socket and mark this handler as no longer in progress.
     public func close() {
         handler?.prepareToClose()
-        request.close()
+        request.release()
     }
     
     /// Invoke the HTTP parser against the specified buffer of data and


### PR DESCRIPTION
Fixed a memory leak in ClientResponse by making sure the HTTPParser object was freed in various error situations. Extra error checking was added.

## Description
Deferred creation of ClientResponse object until the end() function of ClientRequest was called. Insured that ClientResponse.release() was called in various error conditions in ClientRequest.end().
Added error checking in ClientRequest.end() that at least the headers were parsed, before returning as success.

## Motivation and Context
Fix some of the problems in Kitura issue 548

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

… more error checking.