### PR TITLE
Reserve string capacity ahead of time to avoid multiple reallocations

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -133,6 +133,7 @@ public class HTTPServerResponse : ServerResponse {
         }
 
         var headerData = ""
+        headerData.reserveCapacity(254)
         headerData.append("HTTP/1.1 ")
         headerData.append(String(status))
         headerData.append(" ")

--- a/Sources/KituraNet/SPIUtils.swift
+++ b/Sources/KituraNet/SPIUtils.swift
@@ -51,6 +51,7 @@ public class SPIUtils {
         let min = Int(timeStruct.tm_min)
         let sec = Int(timeStruct.tm_sec)
         var s = days[wday]
+        s.reserveCapacity(29)
         s.append(", ")
         s.append(twoDigit[mday])
         s.append(" ")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reserve string capacity ahead of time

## Motivation and Context

Avoid multiple reallocations for a small performance increase

## How Has This Been Tested?

Ran swift test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

