### PR TITLE
Faster NSData to String conversion in HTTPIncomingMessage.addHeader()

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -290,11 +290,12 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
 
     /// Set the header key-value pair
     private func addHeader() {
+        var zero: CChar = 0
+        lastHeaderField.append(&zero, length: 1)
+        let headerKey = String(utf8String: lastHeaderField.bytes.assumingMemoryBound(to: CChar.self))!
 
-        let nsHeaderKey = NSString(bytes: lastHeaderField.bytes, length: lastHeaderField.length, encoding: String.Encoding.utf8.rawValue)!
-        let headerKey = String(describing: nsHeaderKey)
-        let nsHeaderValue = NSString(bytes: lastHeaderValue.bytes, length: lastHeaderValue.length, encoding: String.Encoding.utf8.rawValue)!
-        let headerValue = String(describing: nsHeaderValue)
+        lastHeaderValue.append(&zero, length: 1)
+        let headerValue = String(utf8String: lastHeaderValue.bytes.assumingMemoryBound(to: CChar.self))!
         
         headers.append(headerKey, value: headerValue)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Faster NSData to String conversion in HTTPIncomingMessage.addHeader()

## Motivation and Context

Minor performance increase

## How Has This Been Tested?

Ran swift test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

