### PR TITLE
Ignore closed sockets in epoll_ctl delete failures

### DIFF
--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -177,7 +177,7 @@ class IncomingSocketManager  {
             #if !GCD_ASYNCH && os(Linux)
                 let result = epoll_ctl(epollDescriptor(fd: fileDescriptor), EPOLL_CTL_DEL, fileDescriptor, nil)
                 if result == -1 {
-                    if errno != EBADF {  // Ignore Bad file descriptor, probably got closed.
+                    if errno != EBADF {  // Ignore EBADF error (bad file descriptor), probably got closed.
                         Log.error("epoll_ctl failure. Error code=\(errno). Reason=\(lastError())")
                     }
                 }

--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -176,8 +176,10 @@ class IncomingSocketManager  {
 
             #if !GCD_ASYNCH && os(Linux)
                 let result = epoll_ctl(epollDescriptor(fd: fileDescriptor), EPOLL_CTL_DEL, fileDescriptor, nil)
-                if  result == -1  {
-                    Log.error("epoll_ctl failure. Error code=\(errno). Reason=\(lastError())")
+                if result == -1 {
+                    if errno != EBADF {  // Ignore Bad file descriptor, probably got closed.
+                        Log.error("epoll_ctl failure. Error code=\(errno). Reason=\(lastError())")
+                    }
                 }
             #endif
             


### PR DESCRIPTION
When removing file descriptors from epoll on Linux, ignore errors that are due to invalid file descriptors. They were probably closed in another thread.

## Motivation and Context
Remove false error messages.

## How Has This Been Tested?
Ran swift test.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

