### PR TITLE
Properly write out bytes that didn't fit in the socket write buffer

### DIFF
--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -117,10 +117,19 @@ public class IncomingSocketHandler {
     private func handleWriteHelper() {
         if  writeBuffer.length != 0 {
             do {
-                let written = try socket.write(from: writeBuffer.bytes + writeBufferPosition,
-                                               bufSize: writeBuffer.length - writeBufferPosition)
+                let amountToWrite = writeBuffer.length - writeBufferPosition
                 
-                if written != writeBuffer.length {
+                let written: Int
+                    
+                if amountToWrite > 0 {
+                    written = try socket.write(from: writeBuffer.bytes + writeBufferPosition,
+                                               bufSize: amountToWrite)
+                }
+                else {
+                    written = amountToWrite
+                }
+                
+                if written != amountToWrite {
                     writeBufferPosition += written
                 }
                 else {

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -126,6 +126,10 @@ public class IncomingSocketHandler {
                                                bufSize: amountToWrite)
                 }
                 else {
+                    if amountToWrite < 0 {
+                        Log.error("Amount of bytes to write to file descriptor \(socket.socketfd) was negative \(amountToWrite)")
+                    }
+                    
                     written = amountToWrite
                 }
                 


### PR DESCRIPTION
## Description
KituraNet uses asynchronous I/O on sockets. In that mode writes sometimes only partially write out what was meant to be written. One then needs to wait to be told that there is room in the socket output buffer before writing more bytes. KituraNet does that by buffering the bytes to be written is such cases. 

A change was made to the buffering of these bytes that didn't get written out in the first write. This change improved performance by eliminating the use of Data structs and especially creating a new one on every partial write. The current code attempted to keep a single buffer with an index into the buffer.

The code wasn't completely updated to take into account bytes from the buffer that were already written out.

## Motivation and Context
Fix issue IBM-Swift/Kitura#762

## How Has This Been Tested?
Ran KituraNet unit tests. Tested by @carlbrown the reporter of this issue.

## Checklist:

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
