### PR TITLE
Fix a problem when running using DispatchSource

### DIFF
--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -146,7 +146,7 @@ public class IncomingSocketHandler {
     ///        directly.
     public func handleBufferedReadData() {
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
-            if socket.socketfd != -1 {
+            if socket.socketfd != Socket.SOCKET_INVALID_DESCRIPTOR {
                 socketReaderQueue(fd: socket.socketfd).sync() { [unowned self] in
                     _ = self.handleBufferedReadDataHelper()
                 }

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -146,8 +146,10 @@ public class IncomingSocketHandler {
     ///        directly.
     public func handleBufferedReadData() {
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
-            socketReaderQueue(fd: socket.socketfd).sync() { [unowned self] in
-                _ = self.handleBufferedReadDataHelper()
+            if socket.socketfd != -1 {
+                socketReaderQueue(fd: socket.socketfd).sync() { [unowned self] in
+                    _ = self.handleBufferedReadDataHelper()
+                }
             }
         #endif
     }


### PR DESCRIPTION
Fix a problem when there was data left to process and the socket got closed.

## Description
Added a check that the socket is still valid before using the file descriptor in a hash to pick the ReaderQueue.

## Motivation and Context
Fix issue IBM-Swift/Kitura#784

## How Has This Been Tested?
Tested by the person who opened issue IBM-Swift/Kitra-Sample#39

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
