### PR TITLE
Add support for HTTP 1.1 upgrade requests

### DIFF
--- a/Sources/KituraNet/ConnectionUpgradeFactory.swift
+++ b/Sources/KituraNet/ConnectionUpgradeFactory.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+public protocol ConnectionUpgradeFactory {
+    var name: String { get }
+    
+    func upgrade(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) -> Bool
+}

--- a/Sources/KituraNet/ConnectionUpgradeFactory.swift
+++ b/Sources/KituraNet/ConnectionUpgradeFactory.swift
@@ -16,8 +16,23 @@
 
 import Foundation
 
+/// A class to create new `IncomingSocketProcessor`s for upgraded connections. These factory classes are invoked
+/// when an "upgrade" HTTP request comes to the server for a particular protocol.
 public protocol ConnectionUpgradeFactory {
+    /// The name of the protocol supported by this `ConnectionUpgradeFactory`. A case insensitive compare is made with this name.
     var name: String { get }
     
+    /// "Upgrade" a connection to the protocol supported by this `ConnectionUpgradeFactory`.
+    ///
+    /// - Parameter handler: The `IncomingSocketHandler` that is handling the connection being upgraded.
+    /// - Parameter request: The `ServerRequest` object of the incoming "upgrade" request.
+    /// - Parameter response: The `ServerResponse` object that will be used to send the response of the "upgrade" request.
+    ///
+    /// - Returns: A tuple of the created `IncomingSocketProcessor` and a message to send as the body of the response to
+    ///           the upgrade request. The `IncomingSocketProcessor` should be nil if the upgrade request wasn't successful.
+    ///           If the message is nil, the response will not contain a body.
+    ///
+    /// - Note: The `ConnectionUpgradeFactory` instance doesn't need to work with the `ServerResponse` unless it
+    ///        needs to add special headers to the response.
     func upgrade(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) -> (IncomingSocketProcessor?, String?)
 }

--- a/Sources/KituraNet/ConnectionUpgradeFactory.swift
+++ b/Sources/KituraNet/ConnectionUpgradeFactory.swift
@@ -19,5 +19,5 @@ import Foundation
 public protocol ConnectionUpgradeFactory {
     var name: String { get }
     
-    func upgrade(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) -> Bool
+    func upgrade(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) -> (IncomingSocketProcessor?, String?)
 }

--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+import LoggerAPI
+
+public struct ConnectionUpgrader {
+    static var instance = ConnectionUpgrader()
+    
+    private var registry = [String: ConnectionUpgradeFactory]()
+    
+    public static func register(factory: ConnectionUpgradeFactory) {
+        ConnectionUpgrader.instance.registry[factory.name.lowercased()] = factory
+    }
+    
+    static func clear() {
+        ConnectionUpgrader.instance.registry.removeAll()
+    }
+    
+    func upgradeConnection(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) {
+        guard let protocols = request.headers["Upgrade"] else {
+            do {
+                response.statusCode = HTTPStatusCode.badRequest
+                try response.write(from: "No protocol specified in the Upgrade header")
+                try response.end()
+            }
+            catch {
+                Log.error("Failed to send error response to Upgrade request")
+            }
+            return
+        }
+        
+        var notFound = true
+        let protocolList = protocols.split(separator: ",")
+        for eachProtocol in protocolList {
+            let theProtocol = String(describing: eachProtocol).trimmingCharacters(in: CharacterSet.whitespaces)
+            if theProtocol.characters.count != 0, let factory = registry[theProtocol.lowercased()] {
+                notFound = !factory.upgrade(handler: handler, request: request, response: response)
+            }
+        }
+        
+        if notFound {
+            do {
+                response.statusCode = HTTPStatusCode.notFound
+                try response.write(from: "None of the protocols specified in the Upgrade header are registered")
+                try response.end()
+            }
+            catch {
+                Log.error("Failed to send error response to Upgrade request")
+            }
+        }
+    }
+}

--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -18,19 +18,32 @@ import Foundation
 
 import LoggerAPI
 
+/// The struct that manages the process of upgrading connections from HTTP 1.1 to other protocols.
+///
+///  - Note: There a single instance of this struct in a server.
 public struct ConnectionUpgrader {
     static var instance = ConnectionUpgrader()
     
     private var registry = [String: ConnectionUpgradeFactory]()
     
+    /// Register a `ConnectionUpgradeFactory` class instances used to create appropriate `IncomingSocketProcessor`s
+    /// for upgraded conections
+    ///
+    /// - Parameter factory: The `ConnectionUpgradeFactory` class instance being registered.
     public static func register(factory: ConnectionUpgradeFactory) {
         ConnectionUpgrader.instance.registry[factory.name.lowercased()] = factory
     }
     
+    /// Clear the `ConnectionUpgradeFactory` registry. Used in testing.
     static func clear() {
         ConnectionUpgrader.instance.registry.removeAll()
     }
     
+    /// The function that performs the upgrade.
+    ///
+    /// - Parameter handler: The `IncomingSocketHandler` that is handling the connection being upgraded.
+    /// - Parameter request: The `ServerRequest` object of the incoming "upgrade" request.
+    /// - Parameter response: The `ServerResponse` object that will be used to send the response of the "upgrade" request.
     func upgradeConnection(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) {
         guard let protocols = request.headers["Upgrade"] else {
             do {

--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -47,7 +47,7 @@ public struct ConnectionUpgrader {
         var notFound = true
         let protocolList = protocols.split(separator: ",")
         for eachProtocol in protocolList {
-            let theProtocol = String(describing: eachProtocol).trimmingCharacters(in: CharacterSet.whitespaces)
+            let theProtocol = eachProtocol.first?.trimmingCharacters(in: CharacterSet.whitespaces) ?? ""
             if theProtocol.characters.count != 0, let factory = registry[theProtocol.lowercased()] {
                 notFound = !factory.upgrade(handler: handler, request: request, response: response)
             }
@@ -56,7 +56,10 @@ public struct ConnectionUpgrader {
         if notFound {
             do {
                 response.statusCode = HTTPStatusCode.notFound
-                try response.write(from: "None of the protocols specified in the Upgrade header are registered")
+                let message = "None of the protocols specified in the Upgrade header are registered"
+                response.headers["Content-Type"] = ["text/plain"]
+                response.headers["Content-Length"] = [String(message.characters.count)]
+                try response.write(from: message)
                 try response.end()
             }
             catch {

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -29,6 +29,9 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
 
     /// Minor version for HTTP of the incoming message.
     public private(set) var httpVersionMinor: UInt16?
+    
+    /// HTTP Status code if this message is a response
+    public private(set) var httpStatusCode: HTTPStatusCode = .unknown
 
     /// Set of HTTP headers of the incoming message.
     public var headers = HeadersContainer()
@@ -129,6 +132,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
             }
             length -= numberParsed
         }
+        status.bytesLeft = length
         
         return status
     }
@@ -257,6 +261,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         status.keepAlive = httpParser?.isKeepAlive() ?? false
         status.state = .headersComplete
         
+        httpStatusCode = httpParser?.statusCode ?? .unknown
     }
 
     /// Instructions for when beginning to read a message

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -112,7 +112,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
             let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self) + start
             let (numberParsed, upgrade) = parser.execute(bytes, length: length)
             if upgrade == 1 {
-                // TODO handle new protocol
+                status.upgrade = true
             }
             else if  numberParsed != length  {
                 

--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -115,7 +115,7 @@ public class HTTPServerResponse : ServerResponse {
                 processor.write(from: buffer)
             }
             
-            if !keepAlive {
+            if !keepAlive && !processor.isUpgrade {
                 processor.close()
             }
         }
@@ -152,13 +152,17 @@ public class HTTPServerResponse : ServerResponse {
                 headerData.append("\r\n")
             }
         }
+        
+        let upgrade = processor?.isUpgrade ?? false
         let keepAlive = processor?.isKeepAlive ?? false
-        if  keepAlive {
-            headerData.append("Connection: Keep-Alive\r\n")
-            headerData.append("Keep-Alive: timeout=\(Int(IncomingHTTPSocketProcessor.keepAliveTimeout)), max=\((processor?.numberOfRequests ?? 1) - 1)\r\n")
-        }
-        else {
-            headerData.append("Connection: Close\r\n")
+        if !upgrade {
+            if  keepAlive {
+                headerData.append("Connection: Keep-Alive\r\n")
+                headerData.append("Keep-Alive: timeout=\(Int(IncomingHTTPSocketProcessor.keepAliveTimeout)), max=\((processor?.numberOfRequests ?? 1) - 1)\r\n")
+            }
+            else {
+                headerData.append("Connection: Close\r\n")
+            }
         }
         
         headerData.append("\r\n")

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -139,8 +139,8 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         case .initial:
             break
         case .messageComplete:
-            clientRequestedKeepAlive = parsingStatus.keepAlive
             isUpgrade = parsingStatus.upgrade
+            clientRequestedKeepAlive = parsingStatus.keepAlive && !isUpgrade
             parsingComplete()
         case .reset, .headersComplete:
             break

--- a/Sources/KituraNet/HTTPParser/HTTPParser.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParser.swift
@@ -21,24 +21,16 @@ import Foundation
 
 class HTTPParser {
 
-    ///
     /// A Handle to the HTTPParser C-library
-    ///
     var parser: http_parser
 
-    ///
     /// Settings used for HTTPParser
-    ///
     var settings: http_parser_settings
 
-    ///
     /// Parsing a request? (or a response)
-    ///
     var isRequest = true
 
-    ///
     /// Delegate used for the parsing
-    ///
     var delegate: HTTPParserDelegate? {
 
         didSet {
@@ -52,18 +44,14 @@ class HTTPParser {
         
     }
     
-    ///
     /// Whether to upgrade the HTTP connection to HTTP 1.1
-    ///
     var upgrade = 1
 
-    ///
     /// Initializes a HTTPParser instance
     ///
     /// - Parameter isRequest: whether or not this HTTP message is a request
     ///
     /// - Returns: an HTTPParser instance
-    ///
     init(isRequest: Bool) {
 
         self.isRequest = isRequest
@@ -135,34 +123,32 @@ class HTTPParser {
         reset()	
     }
     
-    ///
     /// Executes the parsing on the byte array
     ///
     /// - Parameter data: pointer to a byte array
     /// - Parameter length: length of the byte array
     ///
     /// - Returns: ???
-    ///
     func execute (_ data: UnsafePointer<Int8>, length: Int) -> (Int, UInt32) {
         let nparsed = http_parser_execute(&parser, &settings, data, length)
         let upgrade = get_upgrade_value(&parser)
         return (nparsed, upgrade)
     }    
 
-    ///
     /// Reset the http_parser context structure.
-    ///
     func reset() {
         http_parser_init(&parser, isRequest ? HTTP_REQUEST : HTTP_RESPONSE)
     }
 
-    ///
     /// Did the request include a Connection: keep-alive header?
-    ///
     func isKeepAlive() -> Bool {
         return isRequest && http_should_keep_alive(&parser) == 1
     }
 
+    /// Get the HTTP status code on responses
+    var statusCode: HTTPStatusCode {
+        return isRequest ? .unknown : HTTPStatusCode(rawValue: Int(parser.status_code)) ?? .unknown
+    }
 }
 
 fileprivate func getDelegate(_ parser: UnsafeMutableRawPointer?) -> HTTPParserDelegate? {
@@ -170,9 +156,7 @@ fileprivate func getDelegate(_ parser: UnsafeMutableRawPointer?) -> HTTPParserDe
     return p?.pointee.data.assumingMemoryBound(to: HTTPParserDelegate.self).pointee
 }
 
-///
 /// Delegate protocol for HTTP parsing stages
-///
 protocol HTTPParserDelegate: class {
     var saveBody : Bool { get }
     func onURL(_ url: UnsafePointer<UInt8>, count: Int)

--- a/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
@@ -53,10 +53,12 @@ struct HTTPParserStatus {
     var state = HTTPParserState.initial
     var error: HTTPParserErrorType? = nil
     var keepAlive = false
+    var upgrade = false
     
     mutating func reset() {
         state = HTTPParserState.initial
         error = nil
         keepAlive = false
+        upgrade = false
     }
 }

--- a/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
@@ -54,6 +54,7 @@ struct HTTPParserStatus {
     var error: HTTPParserErrorType? = nil
     var keepAlive = false
     var upgrade = false
+    var bytesLeft = 0
     
     mutating func reset() {
         state = HTTPParserState.initial

--- a/Tests/KituraNetTests/UpgradeTests.swift
+++ b/Tests/KituraNetTests/UpgradeTests.swift
@@ -1,0 +1,103 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+import XCTest
+
+@testable import KituraNet
+import Socket
+
+class UpgradeTests: XCTestCase {
+    
+    static var allTests : [(String, (UpgradeTests) -> () throws -> Void)] {
+        return [
+            ("testNoRegistrations", testNoRegistrations)
+        ]
+    }
+    
+    override func setUp() {
+        doSetUp()
+    }
+    
+    override func tearDown() {
+        doTearDown()
+    }
+    
+    func testNoRegistrations() {
+        //performServerTest(TestServerDelegate()) { expectation in
+        //    guard let socket = self.sendUpgradeRequest() else { return }
+        //
+        //    guard let response = self.processUpgradeResponse(socket: socket) else { return }
+        //
+        //}
+    }
+    
+    private func sendUpgradeRequest() -> Socket? {
+        var socket: Socket?
+        do {
+            socket = try Socket.create()
+            try socket?.connect(to: "localhost", port: 8090)
+            
+            let request = "GET /test/upgrade HTTP/1.1\r\n" +
+                          "Host: localhost:8090\r\n" +
+                          "Upgrade: testing\r\n" +
+                          "Connection: Upgrade\r\n" +
+                          "\r\n"
+            
+            guard let data = request.data(using: .utf8) else { return nil }
+            
+            try socket?.write(from: data)
+        }
+        catch let error {
+            socket = nil
+            XCTFail("Failed to send upgrade request. Error=\(error)")
+        }
+        return socket
+    }
+    
+    private func processUpgradeResponse(socket: Socket) -> HTTPIncomingMessage? {
+        var response: HTTPIncomingMessage? = HTTPIncomingMessage(isRequest: false)
+        
+        var keepProcessing = true
+        let buffer = NSMutableData()
+        
+        do {
+            while keepProcessing {
+                buffer.length = 0
+                let count = try socket.read(into: buffer)
+                if count != 0 {
+                    
+                }
+                else {
+                    
+                }
+            }
+        }
+        catch let error {
+            response = nil
+            XCTFail("Failed to send upgrade request. Error=\(error)")
+        }
+        return response
+    }
+    
+    class TestServerDelegate : ServerDelegate {
+        
+        func handle(request: ServerRequest, response: ServerResponse) {
+            XCTFail("Server deelgate invoked in an Upgrade scenario")
+        }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -21,8 +21,9 @@ import XCTest
 XCTMain([
        testCase(ClientE2ETests.allTests),
        testCase(ClientRequestTests.allTests),
+       testCase(FastCGIProtocolTests.allTests),
        testCase(HTTPResponseTests.allTests),
        testCase(LargePayloadTests.allTests),
        testCase(ParserTests.allTests),
-       testCase(FastCGIProtocolTests.allTests)
+       testCase(UpgradeTests.allTests)
 ])


### PR DESCRIPTION
Support upgrade requests that upgrade connections from HTTP 1.1 to some other protocol.

## Description
Added a ConnectionUpgrader struct which manages the upgrade process. It contains the registry of factory classes used to create the new IncomingSocketProcessors that will process the data that comes in over the new protocol. This struct also has the coede to handle the upgrade process. 

**Note:** The existing Socket and IncomingSocketHandler for the connection are used after the upgrade process succeeds.

## Motivation and Context
Support WebSockets and potentially other protocols.

## How Has This Been Tested?
Added UpgradeTests to the KituraNet unit tests.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
