### PR TITLE
Improvement of Server lifecycle listener

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -204,13 +204,13 @@ public class FastCGIServer: Server {
 
     @discardableResult
     public func started(callback: @escaping () -> Void) -> Self {
-        self.lifecycleListener.addStartCallback(callback)
+        self.lifecycleListener.addStartCallback(perform: self.state == .started, callback)
         return self
     }
 
     @discardableResult
     public func stopped(callback: @escaping () -> Void) -> Self {
-        self.lifecycleListener.addStopCallback(callback)
+        self.lifecycleListener.addStopCallback(perform: self.state == .stapped, callback)
         return self
     }
 

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -31,7 +31,7 @@ public class FastCGIServer: Server {
     /// Port number for listening for new connections
     public private(set) var port: Int?
 
-    /// Server state
+    /// A server state.
     public private(set) var state: ServerState = .unknown
 
     /// Retrieve an appropriate connection backlog value for our listen socket.
@@ -202,18 +202,33 @@ public class FastCGIServer: Server {
 
     }
 
+    /// Add a new listener for server beeing started
+    ///
+    /// - Parameter callback: The listener callback that will run on server successfull start-up
+    ///
+    /// - Returns: a `FastCGIServer` instance
     @discardableResult
     public func started(callback: @escaping () -> Void) -> Self {
         self.lifecycleListener.addStartCallback(perform: self.state == .started, callback)
         return self
     }
 
+    /// Add a new listener for server beeing stopped
+    ///
+    /// - Parameter callback: The listener callback that will run when server stops
+    ///
+    /// - Returns: a `FastCGIServer` instance
     @discardableResult
     public func stopped(callback: @escaping () -> Void) -> Self {
         self.lifecycleListener.addStopCallback(perform: self.state == .stopped, callback)
         return self
     }
 
+    /// Add a new listener for server throwing an error
+    ///
+    /// - Parameter callback: The listener callback that will run when server throws an error
+    ///
+    /// - Returns: a `FastCGIServer` instance
     @discardableResult
     public func failed(callback: @escaping (Swift.Error) -> Void) -> Self {
         self.lifecycleListener.addFailCallback(callback)

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -131,7 +131,7 @@ public class FastCGIServer: Server {
                 handleClientRequest(socket: clientSocket)
             } while true
         } catch let error as Socket.Error {
-            if if self.state == .stopped
+            if self.state == .stopped
                 && error.errorCode == Int32(Socket.SOCKET_ERR_ACCEPT_FAILED) {
                     self.lifecycleListener.performStopCallbacks()
 
@@ -210,7 +210,7 @@ public class FastCGIServer: Server {
 
     @discardableResult
     public func stopped(callback: @escaping () -> Void) -> Self {
-        self.lifecycleListener.addStopCallback(perform: self.state == .stapped, callback)
+        self.lifecycleListener.addStopCallback(perform: self.state == .stopped, callback)
         return self
     }
 

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -33,7 +33,7 @@ public class HTTPServer: Server {
     /// Port number for listening for new connections.
     public private(set) var port: Int?
 
-    /// Server state
+    /// A server state.
     public private(set) var state: ServerState = .unknown
 
     /// TCP socket used for listening for new connections
@@ -173,18 +173,33 @@ public class HTTPServer: Server {
         }
     }
 
+    /// Add a new listener for server beeing started
+    ///
+    /// - Parameter callback: The listener callback that will run on server successfull start-up
+    ///
+    /// - Returns: a `HTTPServer` instance
     @discardableResult
     public func started(callback: @escaping () -> Void) -> Self {
         self.lifecycleListener.addStartCallback(perform: self.state == .started, callback)
         return self
     }
 
+    /// Add a new listener for server beeing stopped
+    ///
+    /// - Parameter callback: The listener callback that will run when server stops
+    ///
+    /// - Returns: a `HTTPServer` instance
     @discardableResult
     public func stopped(callback: @escaping () -> Void) -> Self {
         self.lifecycleListener.addStopCallback(perform: self.state == .stopped, callback)
         return self
     }
 
+    /// Add a new listener for server throwing an error
+    ///
+    /// - Parameter callback: The listener callback that will run when server throws an error
+    ///
+    /// - Returns: a `HTTPServer` instance
     @discardableResult
     public func failed(callback: @escaping (Swift.Error) -> Void) -> Self {
         self.lifecycleListener.addFailCallback(callback)

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -175,13 +175,13 @@ public class HTTPServer: Server {
 
     @discardableResult
     public func started(callback: @escaping () -> Void) -> Self {
-        self.lifecycleListener.addStartCallback(callback)
+        self.lifecycleListener.addStartCallback(perform: self.state == .started, callback)
         return self
     }
 
     @discardableResult
     public func stopped(callback: @escaping () -> Void) -> Self {
-        self.lifecycleListener.addStopCallback(callback)
+        self.lifecycleListener.addStopCallback(perform: self.state == .stopped, callback)
         return self
     }
 

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -24,6 +24,8 @@ public protocol Server {
 
     var port: Int? { get }
 
+    var state: ServerState { get }
+
     func listen(port: Int, errorHandler: ((Swift.Error) -> Void)?)
 
     static func listen(port: Int, delegate: ServerDelegate, errorHandler: ((Swift.Error) -> Void)?) -> ServerType

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -14,30 +14,60 @@
  * limitations under the License.
  */
 
-import Socket
-
+/// A common protocol for Kitura-net Servers
 public protocol Server {
 
+    /// A type that will be returned by static `listen` method
     associatedtype ServerType
 
+    /// A `ServerDelegate` used for request handling
     weak var delegate: ServerDelegate? { get set }
 
+    /// Port number for listening for new connections.
     var port: Int? { get }
 
+    /// A server state.
     var state: ServerState { get }
 
+    /// Listen for connections on a socket.
+    ///
+    /// - Parameter port: port number for new connections (eg. 8090)
+    /// - Parameter errorHandler: optional callback for error handling
     func listen(port: Int, errorHandler: ((Swift.Error) -> Void)?)
 
+    /// Static method to create a new Server and have it listen for connections.
+    ///
+    /// - Parameter port: port number for accepting new connections
+    /// - Parameter delegate: the delegate handler for HTTP connections
+    /// - Parameter errorHandler: optional callback for error handling
+    ///
+    /// - Returns: a new Server instance
     static func listen(port: Int, delegate: ServerDelegate, errorHandler: ((Swift.Error) -> Void)?) -> ServerType
 
+    /// Stop listening for new connections.
     func stop()
 
+    /// Add a new listener for server beeing started
+    ///
+    /// - Parameter callback: The listener callback that will run on server successfull start-up
+    ///
+    /// - Returns: a Server instance
     @discardableResult
     func started(callback: @escaping () -> Void) -> Self
 
+    /// Add a new listener for server beeing stopped
+    ///
+    /// - Parameter callback: The listener callback that will run when server stops
+    ///
+    /// - Returns: a Server instance
     @discardableResult
     func stopped(callback: @escaping () -> Void) -> Self
 
+    /// Add a new listener for server throwing an error
+    ///
+    /// - Parameter callback: The listener callback that will run when server throws an error
+    ///
+    /// - Returns: a Server instance
     @discardableResult
     func failed(callback: @escaping (Swift.Error) -> Void) -> Self
 }

--- a/Sources/KituraNet/Server/ServerLifecycleListener.swift
+++ b/Sources/KituraNet/Server/ServerLifecycleListener.swift
@@ -14,34 +14,53 @@
  * limitations under the License.
  */
 
-import Socket
-import LoggerAPI
-
+/// A class that is used for storing callbacks and performing them.
 class ServerLifecycleListener {
 
     typealias ErrorClosure = (Swift.Error) -> Void
+
+    /// Callbacks that should be performed when server starts.
     private var startCallbacks = [() -> Void]()
+
+    /// Callbacks that should be performed when server stops.
     private var stopCallbacks = [() -> Void]()
+
+    /// Callbacks that should be performed when server throws an error.
     private var failCallbacks = [ErrorClosure]()
 
+    /// Perform all `start` callbacks.
+    ///
+    /// Performs all `start` callbacks.
     func performStartCallbacks() {
         for callback in self.startCallbacks {
             callback()
         }
     }
 
+    /// Perform all `stop` callbacks.
+    ///
+    /// Performs all `stop` callbacks.
     func performStopCallbacks() {
         for callback in self.stopCallbacks {
             callback()
         }
     }
 
+    /// Perform all `fail` callbacks.
+    ///
+    /// Performs all `fail` callbacks.
+    ///
+    /// - Parameter error: An error that should be processed by callbacks.
     func performFailCallbacks(with error: Swift.Error) {
         for callback in self.failCallbacks {
             callback(error)
         }
     }
 
+    /// Add `start` callback. And perform it immediately if needed.
+    ///
+    /// - Parameter perform: The value indicating should callback be performed immediately or not.
+    /// - Parameter callback: A callback that will be stored for `start` listener.
     func addStartCallback(perform: Bool = false, _ callback: @escaping () -> Void) {
         if perform {
             callback()
@@ -49,6 +68,10 @@ class ServerLifecycleListener {
         self.startCallbacks.append(callback)
     }
 
+    /// Add `stop` callback. And perform it immediately if needed.
+    ///
+    /// - Parameter perform: The value indicating should callback be performed immediately or not.
+    /// - Parameter callback: A callback that will be stored for `stop` listener.
     func addStopCallback(perform: Bool = false, _ callback: @escaping () -> Void) {
         if perform {
             callback()
@@ -56,6 +79,9 @@ class ServerLifecycleListener {
         self.stopCallbacks.append(callback)
     }
 
+    /// Add `fail` callback. And perform it immediately if needed.
+    ///
+    /// - Parameter callback: A callback that will be stored for `fail` listener.
     func addFailCallback(_ callback: @escaping (Swift.Error) -> Void) {
         self.failCallbacks.append(callback)
     }

--- a/Sources/KituraNet/Server/ServerLifecycleListener.swift
+++ b/Sources/KituraNet/Server/ServerLifecycleListener.swift
@@ -42,11 +42,17 @@ class ServerLifecycleListener {
         }
     }
 
-    func addStartCallback(_ callback: @escaping () -> Void) {
+    func addStartCallback(perform: Bool = false, _ callback: @escaping () -> Void) {
+        if perform {
+            callback()
+        }
         self.startCallbacks.append(callback)
     }
 
-    func addStopCallback(_ callback: @escaping () -> Void) {
+    func addStopCallback(perform: Bool = false, _ callback: @escaping () -> Void) {
+        if perform {
+            callback()
+        }
         self.stopCallbacks.append(callback)
     }
 

--- a/Sources/KituraNet/Server/ServerState.swift
+++ b/Sources/KituraNet/Server/ServerState.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public enum ServerState {
+
+    case unknown
+    case started
+    case stopped
+    case failed
+}

--- a/Sources/KituraNet/Server/ServerState.swift
+++ b/Sources/KituraNet/Server/ServerState.swift
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
+/// Enum defining possible server states.
 public enum ServerState {
 
+    /// Initial server state.
     case unknown
+
+    /// State indicating that server has been started.
     case started
+
+    /// State indicating that server was stopped.
     case stopped
+
+    /// State indicating that server has thrown an error.
     case failed
 }

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -24,7 +24,8 @@ class LifecycleListenerTests: XCTestCase {
 
     static var allTests : [(String, (LifecycleListenerTests) -> () throws -> Void)] {
         return [
-            ("testLifecycle", testLifecycle)
+            ("testLifecycle", testLifecycle),
+            ("testLifecycleWithState", testLifecycleWithState)
         ]
     }
 
@@ -63,7 +64,28 @@ class LifecycleListenerTests: XCTestCase {
                 XCTAssertNil(error)
             }
         }
+    }
 
+    func testLifecycleWithState() {
+        var started = false
+        let startExpectation = self.expectation(description: "start")
 
+        let server = HTTP.createServer()
+        server.started {
+            startExpectation.fulfill()
+        }
+        server.listen(port: 8090)
+
+        self.waitForExpectations(timeout: 5) { error in
+            XCTAssertNil(error)
+
+            server.started {
+                started = true
+            }
+
+            XCTAssertTrue(started)
+
+            server.stop()
+        }
     }
 }


### PR DESCRIPTION
Implemented a perform of callbacks added to `.started` and `.stopped` listener if server has already started or stopped listening.
Implemented a `state` property for Server that represents current server state.
Removed private `stopped` propery

## Motivation and Context
IBM-Swift/Kitura#666

## How Has This Been Tested?
Added test to `LifecycleListenerTests.swift`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.