### PR TITLE
Fix the KituraNet tests on Linux

### DIFF
--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -54,7 +54,8 @@ public class IncomingSocketManager  {
         private let epollDescriptors:[Int32]
         private let queues:[DispatchQueue]
 
-        private let epollTimeout: Int32 = 50
+        let epollTimeout: Int32 = 50
+        var runEpoll = true
 
         private func epollDescriptor(fd:Int32) -> Int32 {
             return epollDescriptors[Int(fd) % numberOfEpollTasks];
@@ -116,7 +117,7 @@ public class IncomingSocketManager  {
             var deferredHandlers = [Int32: IncomingSocketHandler]()
             var deferredHandlingNeeded = false
         
-            while  true  {
+            while  runEpoll  {
                 let count = Int(epoll_wait(epollDescriptor, &pollingEvents, Int32(maximumNumberOfEvents), epollTimeout))
             
                 if  count == -1  {

--- a/Tests/KituraNetTests/SocketManagerTests.swift
+++ b/Tests/KituraNetTests/SocketManagerTests.swift
@@ -28,14 +28,25 @@ class SocketManagerTests: XCTestCase {
             ("testHandlerCleanup", testHandlerCleanup)        ]
     }
     
-    let manager = IncomingSocketManager()
+    var manager: IncomingSocketManager?
     
-    func testHandlerCleanup() {
-        defer {
-            #if !GCD_ASYNCH && os(Linux)
+    override func setUp() {
+        manager = IncomingSocketManager()
+    }
+    
+    override func tearDown() {
+        #if !GCD_ASYNCH && os(Linux)
+            if let manager = manager {
                 manager.runEpoll = false
                 usleep(UInt32(manager.epollTimeout) * UInt32(1000))  /* epollTimeout is in milliseconds */
-            #endif
+            }
+        #endif
+    }
+    
+    func testHandlerCleanup() {
+        guard let manager = manager else {
+            XCTFail("Failed to create an IncomingSocketManager.")
+            return
         }
         
         do {

--- a/Tests/KituraNetTests/SocketManagerTests.swift
+++ b/Tests/KituraNetTests/SocketManagerTests.swift
@@ -28,10 +28,17 @@ class SocketManagerTests: XCTestCase {
             ("testHandlerCleanup", testHandlerCleanup)        ]
     }
     
+    let manager = IncomingSocketManager()
+    
     func testHandlerCleanup() {
+        defer {
+            #if !GCD_ASYNCH && os(Linux)
+                manager.runEpoll = false
+                usleep(UInt32(manager.epollTimeout) * UInt32(1000))  /* epollTimeout is in milliseconds */
+            #endif
+        }
+        
         do {
-            let manager = IncomingSocketManager()
-            
             let socket1 = try Socket.create()
             let processor1 = TestIncomingSocketProcessor()
             manager.handle(socket: socket1, processor: processor1)


### PR DESCRIPTION
An attempt at fixing the issues seen in IBM-Swift/Kitura#817

## Description
Have the IncomingSocketManager used in the SocketManager tests properly "stop" by stopping the EPoll thread.

## Motivation and Context
Fix the broken KituraNet builds

## How Has This Been Tested?
I ran swift test on Linux repeatedly. Without this fix, in four of out approximately twenty runs, the failure occurred. With the fix in approximately the same number of runs, the failure was not seen.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
