### PR TITLE
Send Upgrade and Connection headers in the switching protocols response

### DIFF
--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -62,10 +62,12 @@ public struct ConnectionUpgrader {
         var responseBody: String?
         var notFound = true
         let protocolList = protocols.split(separator: ",")
+        var foundProtocol: String?
         for eachProtocol in protocolList {
             let theProtocol = eachProtocol.first?.trimmingCharacters(in: CharacterSet.whitespaces) ?? ""
             if theProtocol.characters.count != 0, let factory = registry[theProtocol.lowercased()] {
                 (processor, responseBody) = factory.upgrade(handler: handler, request: request, response: response)
+                foundProtocol = theProtocol
                 notFound = false
                 break
             }
@@ -82,6 +84,8 @@ public struct ConnectionUpgrader {
             else {
                 if let theProcessor = processor {
                     response.statusCode = .switchingProtocols
+                    response.headers["Upgrade"] = [foundProtocol!]
+                    response.headers["Connection"] = ["Upgrade"]
                     oldProcessor = handler.processor
                     theProcessor.handler = handler
                     handler.processor = theProcessor

--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -62,12 +62,12 @@ public struct ConnectionUpgrader {
         var responseBody: String?
         var notFound = true
         let protocolList = protocols.split(separator: ",")
-        var foundProtocol: String?
+        var protocolName: String?
         for eachProtocol in protocolList {
             let theProtocol = eachProtocol.first?.trimmingCharacters(in: CharacterSet.whitespaces) ?? ""
             if theProtocol.characters.count != 0, let factory = registry[theProtocol.lowercased()] {
                 (processor, responseBody) = factory.upgrade(handler: handler, request: request, response: response)
-                foundProtocol = theProtocol
+                protocolName = theProtocol
                 notFound = false
                 break
             }
@@ -82,9 +82,9 @@ public struct ConnectionUpgrader {
                 try response.write(from: message)
             }
             else {
-                if let theProcessor = processor {
+                if let theProcessor = processor, let theProtocolName = protocolName {
                     response.statusCode = .switchingProtocols
-                    response.headers["Upgrade"] = [foundProtocol!]
+                    response.headers["Upgrade"] = [theProtocolName]
                     response.headers["Connection"] = ["Upgrade"]
                     oldProcessor = handler.processor
                     theProcessor.handler = handler


### PR DESCRIPTION
## Description
Correct the response sent when upgrading protocols. The response is suppose to contain Upgrade and Connection headers. It didn't before this fix.

## Motivation and Context
Get real protocol upgrades to work.

## How Has This Been Tested?
This has been tested as part of the Kitura-WebSocket development work. Without this fix, the Node WebSocket client couldn't upgrade the connection from HTTP to websocket. With it it can. Checking a source or two indicates that indeed the response was suppose to have the headers.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
