### PR TITLE
When errors are thrown by BlueSocket, use message from Socket.Error

### DIFF
--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -171,12 +171,4 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         keepAliveUntil = Date(timeIntervalSinceNow: IncomingHTTPSocketProcessor.keepAliveTimeout).timeIntervalSinceReferenceDate
         handler?.handleBufferedReadData()
     }
-    
-    /// Private method to return a string representation on a value of errno.
-    ///
-    /// - Returns: String containing relevant text about the error.
-    func errorString(error: Int32) -> String {
-        
-        return String(validatingUTF8: strerror(error)) ?? "Error: \(error)"
-    }
 }

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -105,7 +105,7 @@ public class IncomingSocketHandler {
             }
         }
         catch let error as Socket.Error {
-            Log.error(error.description)
+            Log.error("Read from socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
             prepareToClose()
         } catch {
             Log.error("Unexpected error...")
@@ -190,8 +190,8 @@ public class IncomingSocketHandler {
                     writeBufferPosition = 0
                 }
             }
-            catch {
-                Log.error("Write to socket (file descriptor \(socket.socketfd) failed. Error number=\(errno). Message=\(errorString(error: errno)).")
+            catch let error {
+                Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
             }
             
             #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
@@ -256,8 +256,8 @@ public class IncomingSocketHandler {
                 #endif
             }
         }
-        catch {
-            Log.error("Write to socket (file descriptor \(self.socket.socketfd) failed. Error number=\(errno). Message=\(self.errorString(error: errno)).")
+        catch let error {
+            Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
         }
     }
     
@@ -292,13 +292,5 @@ public class IncomingSocketHandler {
         }
         processor?.inProgress = false
         processor?.keepAliveUntil = 0.0
-    }
-    
-    /// Private method to return a string representation on a value of errno.
-    ///
-    /// - Returns: String containing relevant text about the error.
-    func errorString(error: Int32) -> String {
-        
-        return String(validatingUTF8: strerror(error)) ?? "Error: \(error)"
     }
 }

--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -103,8 +103,8 @@ public class IncomingSocketManager  {
                 }
             #endif
         }
-        catch {
-            Log.error("Failed to make incoming socket (File Descriptor=\(socket.socketfd)) non-blocking. Error code=\(errno). Reason=\(lastError())")
+        catch let error {
+            Log.error("Failed to make incoming socket (File Descriptor=\(socket.socketfd)) non-blocking. Error = \(error)")
         }
         
         removeIdleSockets()


### PR DESCRIPTION
## Description
In the actual Socket I/O code Kitura-net was using errno to create an error message. In some cases this doesn't work well as another system call may have been made between the time of the failing system call and the time Kitura-net is trying to report the error..

## Motivation and Context
Correct our error reporting

## How Has This Been Tested?
Ran Kitura-net unit tests on Linux and macOS.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
