### PR TITLE
IBM-Swift/Kitura#836 Catch and log errors in socket.acceptClientConne…

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -149,6 +149,11 @@ public class FastCGIServer: Server {
                 }
             }
         } while self.state == .started && self.listenSocket!.isListening
+
+        if self.state == .started {
+            Log.error("listenSocket closed without stop() being called")
+            stop()
+        }
     }
 
     /// Handle a new client FastCGI request

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -141,7 +141,7 @@ public class FastCGIServer: Server {
                     Log.error("Error in FastCGI socket.acceptClientConnection: \(error)")
                 }
             }
-        } while self.state == .started
+        } while self.state == .started && socket.isListening
     }
 
 

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -58,10 +58,10 @@ public class FastCGIServer: Server {
             self.listenSocket = try Socket.create()
 
             try listenSocket!.listen(on: port, maxBacklogSize: maxPendingConnections)
-            self.state = .started
             Log.info("Listening on port \(port)")
 
             let queuedBlock = DispatchWorkItem(block: {
+                self.state = .started
                 self.lifecycleListener.performStartCallbacks()
                 self.listen()
                 self.lifecycleListener.performStopCallbacks()

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -68,16 +68,13 @@ public class FastCGIServer: Server {
 
             self.state = .failed
             self.lifecycleListener.performFailCallbacks(with: error)
-        }
 
-        guard let socket = self.listenSocket else {
-            // already did a callback on the error handler or logged error
-            return
+            return // TODO - should add throws to listen signature so we can propagate this error up
         }
 
         let queuedBlock = DispatchWorkItem(block: {
             do {
-                try self.listen(socket: socket, port: port)
+                try self.listen(socket: self.listenSocket!, port: port)
             } catch {
                 if let callback = errorHandler {
                     callback(error)

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -157,7 +157,7 @@ public class HTTPServer: Server {
                     Log.error("Error in socket.acceptClientConnection: \(error)")
                 }
             }
-        } while self.state == .started
+        } while self.state == .started && socket.isListening
     }
 
     /// Handle a new client HTTP request

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -163,6 +163,11 @@ public class HTTPServer: Server {
                 }
             }
         } while self.state == .started && self.listenSocket!.isListening
+
+        if self.state == .started {
+            Log.error("listenSocket closed without stop() being called")
+            stop()
+        }
     }
 
     /// Stop listening for new connections.

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -50,14 +50,10 @@ public class HTTPServer: Server {
 
     fileprivate let lifecycleListener = ServerLifecycleListener()
 
-
-    /// Listen for connections on a socket.
-    ///
     /// Listens for connections on a socket
     ///
-    /// - Parameter port: port number for new connections (eg. 8090)
-    /// - Parameter errorHandler: optional callback for error handling
-    public func listen(port: Int, errorHandler: ((Swift.Error) -> Void)? = nil) {
+    /// - Parameter on: port number for new connections (eg. 8090)
+    public func listen(on port: Int) throws {
         self.port = port
         do {
             self.listenSocket = try Socket.create()
@@ -65,49 +61,64 @@ public class HTTPServer: Server {
             // If SSL config has been created,
             // create and attach the SSLService delegate to the socket
             if let sslConfig = sslConfig {
-                self.listenSocket?.delegate = try SSLService(usingConfiguration: sslConfig);
+                self.listenSocket!.delegate = try SSLService(usingConfiguration: sslConfig);
             }
+
+            try listenSocket!.listen(on: port, maxBacklogSize: maxPendingConnections)
+            self.state = .started
+
+            if let delegate = listenSocket!.delegate {
+                Log.info("Listening on port \(port) (delegate: \(delegate))")
+            } else {
+                Log.info("Listening on port \(port)")
+            }
+
+            let queuedBlock = DispatchWorkItem(block: {
+                self.lifecycleListener.performStartCallbacks()
+                self.listen()
+                self.lifecycleListener.performStopCallbacks()
+                self.listenSocket = nil
+            })
+
+            ListenerGroup.enqueueAsynchronously(on: DispatchQueue.global(), block: queuedBlock)
+        }
+        catch let error {
+            self.state = .failed
+            self.lifecycleListener.performFailCallbacks(with: error)
+            throw error
+        }
+    }
+
+    /// Static method to create a new HTTPServer and have it listen for connections.
+    ///
+    /// - Parameter on: port number for accepting new connections
+    /// - Parameter delegate: the delegate handler for HTTP connections
+    ///
+    /// - Returns: a new `HTTPServer` instance
+    public static func listen(on port: Int, delegate: ServerDelegate) throws -> HTTPServer {
+        let server = HTTP.createServer()
+        server.delegate = delegate
+        try server.listen(on: port)
+        return server
+    }
+
+    /// Listens for connections on a socket
+    ///
+    /// - Parameter port: port number for new connections (eg. 8090)
+    /// - Parameter errorHandler: optional callback for error handling
+    @available(*, deprecated, message: "use 'listen(on:) throws' with 'server.failed(callback:)' instead")
+    public func listen(port: Int, errorHandler: ((Swift.Error) -> Void)? = nil) {
+        do {
+            try listen(on: port)
         }
         catch let error {
             if let callback = errorHandler {
                 callback(error)
             } else {
-                if let socketError = error as? Socket.Error {
-                    Log.error("Error creating socket: \(socketError)")
-                } else if let sslError = error as? SSLError {
-                    // we have to catch SSLErrors separately since we are
-                    // calling SSLService.Configuration
-                    Log.error("Error in SSLService init: \(sslError)")
-                } else {
-                    Log.error("Unexpected error: \(error)")
-                }
+                Log.error("Error listening on port \(port): \(error)")
             }
-
-            self.state = .failed
-            self.lifecycleListener.performFailCallbacks(with: error)
-
-            return // TODO - should add throws to listen signature so we can propagate this error up
         }
-
-        let queuedBlock = DispatchWorkItem(block: {
-            do {
-                try self.listen(socket: self.listenSocket!, port: port)
-            } catch {
-                if let callback = errorHandler {
-                    callback(error)
-                } else {
-                    Log.error("Error listening on socket: \(error)")
-                }
-
-                self.state = .failed
-                self.lifecycleListener.performFailCallbacks(with: error)
-            }
-        })
-
-        ListenerGroup.enqueueAsynchronously(on: DispatchQueue.global(), block: queuedBlock)
     }
-
-
 
     /// Static method to create a new HTTPServer and have it listen for connections.
     ///
@@ -116,6 +127,7 @@ public class HTTPServer: Server {
     /// - Parameter errorHandler: optional callback for error handling
     ///
     /// - Returns: a new `HTTPServer` instance
+    @available(*, deprecated, message: "use 'listen(on:delegate:) throws' with 'server.failed(callback:)' instead")
     public static func listen(port: Int, delegate: ServerDelegate, errorHandler: ((Swift.Error) -> Void)? = nil) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
@@ -123,65 +135,40 @@ public class HTTPServer: Server {
         return server
     }
 
-    /// Handle instructions for listening on a socket
-    ///
-    /// - Parameter socket: socket to use for connecting
-    /// - Parameter port: number to listen on
-    private func listen(socket: Socket, port: Int) throws {
-        try socket.listen(on: port, maxBacklogSize: maxPendingConnections)
-        self.state = .started
-        if let delegate = socket.delegate {
-            Log.info("Listening on port \(port) (delegate: \(delegate))")
-        } else {
-            Log.info("Listening on port \(port)")
-        }
-
-        self.lifecycleListener.performStartCallbacks()
-        defer {
-            self.lifecycleListener.performStopCallbacks()
-        }
-
+    /// Listen on socket while server is started
+    private func listen() {
         repeat {
             do {
-                let clientSocket = try socket.acceptClientConnection()
+                let clientSocket = try self.listenSocket!.acceptClientConnection()
                 Log.verbose("Accepted connection from: " +
                     "\(clientSocket.remoteHostname):\(clientSocket.remotePort)")
-                handleClientRequest(socket: clientSocket)
-            } catch let error as Socket.Error {
+
+                if let delegate = delegate {
+                    socketManager.handle(socket: clientSocket, processor: IncomingHTTPSocketProcessor(socket: clientSocket, using: delegate))
+                }
+            } catch let error {
                 if self.state == .stopped {
-                    if error.errorCode == Int32(Socket.SOCKET_ERR_ACCEPT_FAILED) {
-                        Log.info("Server has stopped listening")
+                    if let socketError = error as? Socket.Error {
+                        if socketError.errorCode == Int32(Socket.SOCKET_ERR_ACCEPT_FAILED) {
+                            Log.info("Server has stopped listening")
+                        } else {
+                            Log.warning("Socket.Error accepting client connection after server stopped: \(error)")
+                        }
                     } else {
-                        Log.warning("Error in socket.acceptClientConnection after server stopped: \(error)")
+                        Log.warning("Error accepting client connection after server stopped: \(error)")
                     }
                 } else {
-                    Log.error("Error in socket.acceptClientConnection: \(error)")
+                    Log.error("Error accepting client connection: \(error)")
+                    self.lifecycleListener.performClientConnectionFailCallbacks(with: error)
                 }
             }
-        } while self.state == .started && socket.isListening
-    }
-
-    /// Handle a new client HTTP request
-    ///
-    /// - Parameter clientSocket: the socket used for connecting
-    private func handleClientRequest(socket clientSocket: Socket, fromKeepAlive: Bool=false) {
-
-        guard let delegate = delegate else {
-            return
-        }
-
-        socketManager.handle(socket: clientSocket, processor: IncomingHTTPSocketProcessor(socket: clientSocket, using: delegate))
+        } while self.state == .started && self.listenSocket!.isListening
     }
 
     /// Stop listening for new connections.
     public func stop() {
-        defer {
-            delegate = nil
-        }
-        if let listenSocket = listenSocket {
-            self.state = .stopped
-            listenSocket.close()
-        }
+        self.state = .stopped
+        listenSocket?.close()
     }
 
     /// Add a new listener for server beeing started
@@ -214,6 +201,17 @@ public class HTTPServer: Server {
     @discardableResult
     public func failed(callback: @escaping (Swift.Error) -> Void) -> Self {
         self.lifecycleListener.addFailCallback(callback)
+        return self
+    }
+
+    /// Add a new listener for when listenSocket.acceptClientConnection throws an error
+    ///
+    /// - Parameter callback: The listener callback that will run
+    ///
+    /// - Returns: a Server instance
+    @discardableResult
+    public func clientConnectionFailed(callback: @escaping (Swift.Error) -> Void) -> Self {
+        self.lifecycleListener.addClientConnectionFailCallback(callback)
         return self
     }
 

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -65,7 +65,6 @@ public class HTTPServer: Server {
             }
 
             try listenSocket!.listen(on: port, maxBacklogSize: maxPendingConnections)
-            self.state = .started
 
             if let delegate = listenSocket!.delegate {
                 Log.info("Listening on port \(port) (delegate: \(delegate))")
@@ -74,6 +73,7 @@ public class HTTPServer: Server {
             }
 
             let queuedBlock = DispatchWorkItem(block: {
+                self.state = .started
                 self.lifecycleListener.performStartCallbacks()
                 self.listen()
                 self.lifecycleListener.performStopCallbacks()

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -31,8 +31,22 @@ public protocol Server {
 
     /// Listen for connections on a socket.
     ///
+    /// - Parameter on: port number for new connections (eg. 8090)
+    func listen(on port: Int) throws
+
+    /// Static method to create a new Server and have it listen for connections.
+    ///
+    /// - Parameter on: port number for accepting new connections
+    /// - Parameter delegate: the delegate handler for HTTP connections
+    ///
+    /// - Returns: a new Server instance
+    static func listen(on port: Int, delegate: ServerDelegate) throws -> ServerType
+
+    /// Listen for connections on a socket.
+    ///
     /// - Parameter port: port number for new connections (eg. 8090)
     /// - Parameter errorHandler: optional callback for error handling
+    @available(*, deprecated, message: "use 'listen(on:) throws' with 'server.failed(callback:)' instead")
     func listen(port: Int, errorHandler: ((Swift.Error) -> Void)?)
 
     /// Static method to create a new Server and have it listen for connections.
@@ -42,6 +56,7 @@ public protocol Server {
     /// - Parameter errorHandler: optional callback for error handling
     ///
     /// - Returns: a new Server instance
+    @available(*, deprecated, message: "use 'listen(on:delegate:) throws' with 'server.failed(callback:)' instead")
     static func listen(port: Int, delegate: ServerDelegate, errorHandler: ((Swift.Error) -> Void)?) -> ServerType
 
     /// Stop listening for new connections.
@@ -70,4 +85,12 @@ public protocol Server {
     /// - Returns: a Server instance
     @discardableResult
     func failed(callback: @escaping (Swift.Error) -> Void) -> Self
+
+    /// Add a new listener for when listenSocket.acceptClientConnection throws an error
+    ///
+    /// - Parameter callback: The listener callback that will run
+    ///
+    /// - Returns: a Server instance
+    @discardableResult
+    func clientConnectionFailed(callback: @escaping (Swift.Error) -> Void) -> Self
 }

--- a/Sources/KituraNet/Server/ServerLifecycleListener.swift
+++ b/Sources/KituraNet/Server/ServerLifecycleListener.swift
@@ -28,6 +28,9 @@ class ServerLifecycleListener {
     /// Callbacks that should be performed when server throws an error.
     private var failCallbacks = [ErrorClosure]()
 
+    /// Callbacks that should be performed when listenSocket.acceptClientConnection throws an error.
+    private var clientConnectionFailCallbacks = [ErrorClosure]()
+
     /// Perform all `start` callbacks.
     ///
     /// Performs all `start` callbacks.
@@ -53,6 +56,15 @@ class ServerLifecycleListener {
     /// - Parameter error: An error that should be processed by callbacks.
     func performFailCallbacks(with error: Swift.Error) {
         for callback in self.failCallbacks {
+            callback(error)
+        }
+    }
+
+    /// Performs all `clientConnectionFail` callbacks.
+    ///
+    /// - Parameter error: An error that should be processed by callbacks.
+    func performClientConnectionFailCallbacks(with error: Swift.Error) {
+        for callback in self.clientConnectionFailCallbacks {
             callback(error)
         }
     }
@@ -84,5 +96,12 @@ class ServerLifecycleListener {
     /// - Parameter callback: A callback that will be stored for `fail` listener.
     func addFailCallback(_ callback: @escaping (Swift.Error) -> Void) {
         self.failCallbacks.append(callback)
+    }
+
+    /// Add `clientConnectionFail` callback. And perform it immediately if needed.
+    ///
+    /// - Parameter callback: A callback that will be stored for `clientConnectionFail` listener.
+    func addClientConnectionFailCallback(_ callback: @escaping (Swift.Error) -> Void) {
+        self.clientConnectionFailCallbacks.append(callback)
     }
 }

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -39,7 +39,8 @@ extension KituraNetTest {
 
     func performServerTest(_ delegate: ServerDelegate, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
         do {
-            let server = try setupServer(port: 8090, delegate: delegate)
+            let server = HTTP.createServer()
+            server.delegate = delegate
 
             var expectations: [XCTestExpectation] = []
 
@@ -60,6 +61,9 @@ extension KituraNetTest {
                     }
                 }
             }
+
+            // server.started callback above needs to be set before server.listen
+            try server.listen(on: 8090)
 
             waitExpectation(timeout: 10) { error in
                 // blocks test until request completes
@@ -85,10 +89,6 @@ extension KituraNetTest {
             requestModifier(req)
         }
         req.end()
-    }
-
-    private func setupServer(port: Int, delegate: ServerDelegate) throws -> HTTPServer {
-        return try HTTPServer.listen(on: port, delegate: delegate)
     }
 }
 


### PR DESCRIPTION
## Description
- Deprecate listen methods with error handling callbacks
- Add replacement methods that propagate up server errors and use lifecycleListener for error callbacks
- Catch and log errors in socket.acceptClientConnection() without stopping listen()
- Refactor so server exit does not rely on error being thrown
- Refactor so lifecycleListener.performStopCallbacks() is always called when server stops
- Add and update tests for above changes
- Make the above changes for both HTTPServer and FastCGIServer

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

…ction without stopping listen