### PR TITLE
Include full URL in ServerRequests and deprecate urlString:String and url:Data in favor of urlComponents:URLComponents

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -48,12 +48,18 @@ public class FastCGIServerRequest : ServerRequest {
     private var requestUri : String? = nil
 
     /// The URL from the request in string form
-    @available(*, deprecated, message: "use 'urlComponents' instead")
-    public var urlString : String { return urlComponents.string ?? "" }
+    /// This contains just the path and query parameters starting with '/'
+    /// Use "urlComponents" for the full URL
+    @available(*, deprecated, message:
+        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+    public var urlString : String { return requestUri ?? "" }
 
     /// The URL from the request in UTF-8 form
-    @available(*, deprecated, message: "use 'urlComponents' instead")
-    public var url : Data { return urlComponents.string?.data(using: .utf8) ?? Data() }
+    /// This contains just the path and query parameters starting with '/'
+    /// Use "urlComponents" for the full URL
+    @available(*, deprecated, message:
+        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+    public var url : Data { return requestUri?.data(using: .utf8) ?? Data() }
 
     /// The URL from the request as URLComponents
     public private(set) var urlComponents = URLComponents()

--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -40,14 +40,19 @@ public class FastCGIServerRequest : ServerRequest {
     
     /// The HTTP Method specified in the request
     public private(set) var method: String = ""
-    
+
     /// URI Component received from FastCGI
     private var requestUri : String? = nil
 
-    /// The URL from the request if properly received
-    public private(set) var url : URL?
+    /// The URL from the request in string form
+    @available(*, deprecated, message: "use 'urlComponents' instead")
+    public var urlString : String { return urlComponents.string ?? "" }
 
-    /// The parsed URL as URLComponents
+    /// The URL from the request in UTF-8 form
+    @available(*, deprecated, message: "use 'urlComponents' instead")
+    public var url : Data { return urlComponents.string?.data(using: .utf8) ?? Data() }
+
+    /// The URL from the request as URLComponents
     public private(set) var urlComponents = URLComponents()
 
     /// Chunk of body read in by the http_parser, filled by callbacks to onBody
@@ -130,12 +135,6 @@ public class FastCGIServerRequest : ServerRequest {
     /// Proces the original request URI
     func postProcessUrlParameter() -> Void {
         if let requestUri = requestUri, requestUri.characters.count > 0 {
-            if let url = URL(string: requestUri) {
-                self.url = url
-            } else {
-                Log.error("URL init failed from REQUEST_URI header value: \(requestUri)")
-            }
-
             if let urlComponents = URLComponents(string: requestUri) {
                 self.urlComponents = urlComponents
             } else {

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -47,12 +47,18 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     public private(set) var urlComponents = URLComponents()
 
     /// The URL from the request in string form
-    @available(*, deprecated, message: "use 'urlComponents' instead")
-    public var urlString : String { return urlComponents.string ?? "" }
+    /// This contains just the path and query parameters starting with '/'
+    /// Use "urlComponents" for the full URL
+    @available(*, deprecated, message:
+        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+    public var urlString : String { return String(data: pathAndQueryParams, encoding: .utf8) ?? "" }
 
     /// The URL from the request in UTF-8 form
-    @available(*, deprecated, message: "use 'urlComponents' instead")
-    public var url : Data { return urlComponents.string?.data(using: .utf8) ?? Data() }
+    /// This contains just the path and query parameters starting with '/'
+    /// Use "urlComponents" for the full URL
+    @available(*, deprecated, message:
+        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+    public var url : Data { return pathAndQueryParams }
 
     /// Parsed path and optional query parameters of the request.
     private var pathAndQueryParams = Data()

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -40,6 +40,9 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     /// HTTP Method of the incoming message.
     public private(set) var method: String = "" 
 
+    /// is a request? (or a response)
+    public let isRequest: Bool
+
     /// socket signature of the request.
     public private(set) var signature: Socket.Signature?
 
@@ -100,6 +103,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     ///
     /// - Returns: an IncomingMessage instance
     init (isRequest: Bool, signature: Socket.Signature? = nil) {
+        self.isRequest = isRequest
         self.signature = signature
         httpParser = HTTPParser(isRequest: isRequest)
 
@@ -275,7 +279,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
             addHeader()
         }
 
-        if self is ServerRequest { // skip if ClientResponse
+        if isRequest {
             var url = ""
             if let isSecure = signature?.isSecure {
                 url.append(isSecure ? "https://" : "http://")

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -39,15 +39,20 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
 
     /// HTTP Method of the incoming message.
     public private(set) var method: String = "" 
-    
+
     /// socket signature of the request.
     public private(set) var signature: Socket.Signature?
-    
-    /// The URL from the request if properly received.
-    public private(set) var url : URL?
 
-    /// The parsed URL as URLComponents.
+    /// The URL from the request as URLComponents.
     public private(set) var urlComponents = URLComponents()
+
+    /// The URL from the request in string form
+    @available(*, deprecated, message: "use 'urlComponents' instead")
+    public var urlString : String { return urlComponents.string ?? "" }
+
+    /// The URL from the request in UTF-8 form
+    @available(*, deprecated, message: "use 'urlComponents' instead")
+    public var url : Data { return urlComponents.string?.data(using: .utf8) ?? Data() }
 
     /// Parsed path and optional query parameters of the request.
     private var pathAndQueryParams = Data()
@@ -287,12 +292,6 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                 Log.error("Invalid utf8 encoded path received in onURL: \(self.pathAndQueryParams)")
             }
 
-            if let url = URL(string: url) {
-                self.url = url
-            } else {
-                Log.error("URL init failed from parsed value: \(url)")
-            }
-
             if let urlComponents = URLComponents(string: url) {
                 self.urlComponents = urlComponents
             } else {
@@ -335,7 +334,6 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         lastHeaderWasAValue = false
         saveBody = true
         pathAndQueryParams.count = 0
-        url = nil
         urlComponents = URLComponents()
         headers.removeAll()
         bodyChunk.reset()

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -56,17 +56,18 @@ public class HTTPServer: Server {
     public func listen(on port: Int) throws {
         self.port = port
         do {
-            self.listenSocket = try Socket.create()
+            let socket = try Socket.create()
+            self.listenSocket = socket
 
             // If SSL config has been created,
             // create and attach the SSLService delegate to the socket
             if let sslConfig = sslConfig {
-                self.listenSocket!.delegate = try SSLService(usingConfiguration: sslConfig);
+                socket.delegate = try SSLService(usingConfiguration: sslConfig);
             }
 
-            try listenSocket!.listen(on: port, maxBacklogSize: maxPendingConnections)
+            try socket.listen(on: port, maxBacklogSize: maxPendingConnections)
 
-            if let delegate = listenSocket!.delegate {
+            if let delegate = socket.delegate {
                 Log.info("Listening on port \(port) (delegate: \(delegate))")
             } else {
                 Log.info("Listening on port \(port)")
@@ -75,7 +76,7 @@ public class HTTPServer: Server {
             let queuedBlock = DispatchWorkItem(block: {
                 self.state = .started
                 self.lifecycleListener.performStartCallbacks()
-                self.listen()
+                self.listen(listenSocket: socket)
                 self.lifecycleListener.performStopCallbacks()
                 self.listenSocket = nil
             })
@@ -136,10 +137,10 @@ public class HTTPServer: Server {
     }
 
     /// Listen on socket while server is started
-    private func listen() {
+    private func listen(listenSocket: Socket) {
         repeat {
             do {
-                let clientSocket = try self.listenSocket!.acceptClientConnection()
+                let clientSocket = try listenSocket.acceptClientConnection()
                 Log.verbose("Accepted connection from: " +
                     "\(clientSocket.remoteHostname):\(clientSocket.remotePort)")
 
@@ -162,7 +163,7 @@ public class HTTPServer: Server {
                     self.lifecycleListener.performClientConnectionFailCallbacks(with: error)
                 }
             }
-        } while self.state == .started && self.listenSocket!.isListening
+        } while self.state == .started && listenSocket.isListening
 
         if self.state == .started {
             Log.error("listenSocket closed without stop() being called")

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -40,6 +40,6 @@ public class HTTPServerRequest: HTTPIncomingMessage, ServerRequest {
     init (socket: Socket) {
         clientSocket = socket
         
-        super.init(isRequest: true)
+        super.init(isRequest: true, signature: clientSocket.signature)
     }
 }

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -23,13 +23,13 @@ public protocol ServerRequest: class {
     
     /// The set of headers received with the incoming request
     var headers : HeadersContainer { get set }
-    
-    /// The URL from the request in string form
-    var urlString : String { get }
-    
-    /// The URL from the request in UTF-8 form
-    var url : Data { get }
 
+    /// The URL from the request if properly received
+    var url : URL? { get }
+
+    /// The parsed URL as URLComponents
+    var urlComponents : URLComponents { get }
+    
     /// The IP address of the client
     var remoteAddress: String { get }
     

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -25,11 +25,17 @@ public protocol ServerRequest: class {
     var headers : HeadersContainer { get set }
 
     /// The URL from the request in string form
-    @available(*, deprecated, message: "use 'urlComponents' instead")
+    /// This contains just the path and query parameters starting with '/'
+    /// Use "urlComponents" for the full URL
+    @available(*, deprecated, message:
+        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
     var urlString : String { get }
 
     /// The URL from the request in UTF-8 form
-    @available(*, deprecated, message: "use 'urlComponents' instead")
+    /// This contains just the path and query parameters starting with '/'
+    /// Use "urlComponents" for the full URL
+    @available(*, deprecated, message:
+        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
     var url : Data { get }
 
     /// The URL from the request as URLComponents

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -24,12 +24,17 @@ public protocol ServerRequest: class {
     /// The set of headers received with the incoming request
     var headers : HeadersContainer { get set }
 
-    /// The URL from the request if properly received
-    var url : URL? { get }
+    /// The URL from the request in string form
+    @available(*, deprecated, message: "use 'urlComponents' instead")
+    var urlString : String { get }
 
-    /// The parsed URL as URLComponents
+    /// The URL from the request in UTF-8 form
+    @available(*, deprecated, message: "use 'urlComponents' instead")
+    var url : Data { get }
+
+    /// The URL from the request as URLComponents
     var urlComponents : URLComponents { get }
-    
+
     /// The IP address of the client
     var remoteAddress: String { get }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Include full URL in ServerRequests and deprecate urlString:String and url:Data in favor of urlComponents:URLComponents

Addresses IBM-Swift/Kitura#830

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

…LComponents including scheme and host