### PR TITLE
Add the socketClosed callback to the IncomingSocketProessor protocol

### DIFF
--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -119,6 +119,10 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         request.release()
     }
     
+    /// Called by the `IncomingSocketHandler` to tell us that the socket has been closed
+    /// by the remote side. This is ignored at this time.
+    public func socketClosed() {}
+    
     /// Invoke the HTTP parser against the specified buffer of data and
     /// convert the HTTP parser's status to our own.
     private func parse(_ buffer: NSData) {

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -100,6 +100,7 @@ public class IncomingSocketHandler {
             }
             else {
                 if  socket.remoteConnectionClosed  {
+                    processor?.socketClosed()
                     prepareToClose()
                 }
             }

--- a/Sources/KituraNet/IncomingSocketProcessor.swift
+++ b/Sources/KituraNet/IncomingSocketProcessor.swift
@@ -52,4 +52,8 @@ public protocol IncomingSocketProcessor: class {
     
     /// Close the socket and mark this handler as no longer in progress.
     func close()
+    
+    /// Called by the `IncomingSocketHandler` to tell the `IncomingSocketProcessor` that the
+    /// socket has been closed by the remote side.
+    func socketClosed()
 }

--- a/Tests/KituraNetTests/TestIncomingSocketProcessor.swift
+++ b/Tests/KituraNetTests/TestIncomingSocketProcessor.swift
@@ -41,4 +41,6 @@ class TestIncomingSocketProcessor: IncomingSocketProcessor {
     public func close() {
         handler?.prepareToClose()
     }
+    
+    public func socketClosed() {}
 }


### PR DESCRIPTION
Add a callback to tell IncomingSocketProessors that the socket was closed by the remote side.

## Motivation and Context
In some protocols the socket is kept open for bi-directional communication. The server side may also be keeping track of its clients. A way was needed to tell the parts of the server that need to know that the client has closed the socket.

## How Has This Been Tested?
On of the UpgradeTests was extended to include a functioning socketClosed callback

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
