### PR TITLE
Ignore other errors that occur due to file descriptors being closed and potentially reused.

### DIFF
--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -207,7 +207,8 @@ public class IncomingSocketManager  {
             #if !GCD_ASYNCH && os(Linux)
                 let result = epoll_ctl(epollDescriptor(fd: fileDescriptor), EPOLL_CTL_DEL, fileDescriptor, nil)
                 if result == -1 {
-                    if errno != EBADF {  // Ignore EBADF error (bad file descriptor), probably got closed.
+                    if errno != EBADF &&     // Ignore EBADF error (bad file descriptor), probably got closed.
+                           errno != ENOENT { // Ignore ENOENT error (No such file or directory), probably got closed.
                         Log.error("epoll_ctl failure. Error code=\(errno). Reason=\(lastError())")
                     }
                 }


### PR DESCRIPTION
## Description
The IncomingSocketHandler code sometimes hicups when sockets have been closed already but we didn't remove the IncomingSocketHandler. The code needs to ignore certain errors.

## Motivation and Context
Close issue IBM-Swift/Kitura#877

## How Has This Been Tested?
Ran KituraNet unit tests, will be verified by the reporter of the problem.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
