### PR TITLE
Revert "Include full URL in ServerRequests and deprecate urlString:String and url:Data in favor of urlComponents:URLComponents"

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -55,16 +55,15 @@ public class FastCGIServer: Server {
     public func listen(on port: Int) throws {
         self.port = port
         do {
-            let socket = try Socket.create()
-            self.listenSocket = socket
+            self.listenSocket = try Socket.create()
 
-            try socket.listen(on: port, maxBacklogSize: maxPendingConnections)
+            try listenSocket!.listen(on: port, maxBacklogSize: maxPendingConnections)
             Log.info("Listening on port \(port)")
 
             let queuedBlock = DispatchWorkItem(block: {
                 self.state = .started
                 self.lifecycleListener.performStartCallbacks()
-                self.listen(listenSocket: socket)
+                self.listen()
                 self.lifecycleListener.performStopCallbacks()
                 self.listenSocket = nil
             })
@@ -126,10 +125,10 @@ public class FastCGIServer: Server {
     }
 
     /// Listen on socket while server is started
-    private func listen(listenSocket: Socket) {
+    private func listen() {
         repeat {
             do {
-                let clientSocket = try listenSocket.acceptClientConnection()
+                let clientSocket = try self.listenSocket!.acceptClientConnection()
                 Log.verbose("Accepted connection from: " +
                     "\(clientSocket.remoteHostname):\(clientSocket.remotePort)")
                 handleClientRequest(socket: clientSocket)
@@ -149,7 +148,7 @@ public class FastCGIServer: Server {
                     self.lifecycleListener.performClientConnectionFailCallbacks(with: error)
                 }
             }
-        } while self.state == .started && listenSocket.isListening
+        } while self.state == .started && self.listenSocket!.isListening
 
         if self.state == .started {
             Log.error("listenSocket closed without stop() being called")

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -40,6 +40,6 @@ public class HTTPServerRequest: HTTPIncomingMessage, ServerRequest {
     init (socket: Socket) {
         clientSocket = socket
         
-        super.init(isRequest: true, signature: clientSocket.signature)
+        super.init(isRequest: true)
     }
 }

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -23,23 +23,12 @@ public protocol ServerRequest: class {
     
     /// The set of headers received with the incoming request
     var headers : HeadersContainer { get set }
-
+    
     /// The URL from the request in string form
-    /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
-    @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
     var urlString : String { get }
-
+    
     /// The URL from the request in UTF-8 form
-    /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
-    @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
     var url : Data { get }
-
-    /// The URL from the request as URLComponents
-    var urlComponents : URLComponents { get }
 
     /// The IP address of the client
     var remoteAddress: String { get }


### PR DESCRIPTION
Reverts IBM-Swift/Kitura-net#142. This branch was mergeable. The Kitura one isn't.

Sorry for the mess.