### PR TITLE
Reduce priority of `Connection reset by peer` messages.

### DIFF
--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -106,7 +106,7 @@ public class IncomingSocketHandler {
             }
         }
         catch let error as Socket.Error {
-            if error.errorCode == Int32(Socket.SOCKET_ERR_RECV_FAILED) {
+            if error.errorCode == Int32(Socket.SOCKET_ERR_CONNECTION_RESET) {
                 Log.debug("Read from socket (file descriptor \(socket.socketfd)) reset. Error = \(error).")
             } else {
                 Log.error("Read from socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
@@ -196,7 +196,11 @@ public class IncomingSocketHandler {
                 }
             }
             catch let error {
-                Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+                if let error = error as? Socket.Error, error.errorCode == Int32(Socket.SOCKET_ERR_CONNECTION_RESET) {
+                    Log.debug("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+                } else {
+                    Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+                }
             }
             
             #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
@@ -262,7 +266,11 @@ public class IncomingSocketHandler {
             }
         }
         catch let error {
-            Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+            if let error = error as? Socket.Error, error.errorCode == Int32(Socket.SOCKET_ERR_CONNECTION_RESET) {
+                Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+            } else {
+                Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+            }
         }
     }
     

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -267,7 +267,7 @@ public class IncomingSocketHandler {
         }
         catch let error {
             if let error = error as? Socket.Error, error.errorCode == Int32(Socket.SOCKET_ERR_CONNECTION_RESET) {
-                Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+                Log.debug("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
             } else {
                 Log.error("Write to socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
             }

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -106,7 +106,11 @@ public class IncomingSocketHandler {
             }
         }
         catch let error as Socket.Error {
-            Log.error("Read from socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+            if error.errorCode == Int32(Socket.SOCKET_ERR_RECV_FAILED) {
+                Log.debug("Read from socket (file descriptor \(socket.socketfd)) reset. Error = \(error).")
+            } else {
+                Log.error("Read from socket (file descriptor \(socket.socketfd)) failed. Error = \(error).")
+            }
             prepareToClose()
         } catch {
             Log.error("Unexpected error...")


### PR DESCRIPTION
Under common operation, there are a lot of `Connection reset by peer` messages that get logged by Kitura-Net, especially when put behind an HAProxy (see http://discourse.haproxy.org/t/haproxy-1-5-4-1-5-18-is-sending-rst-ack-in-for-closure-to-httpchk-instead-of-fin-ack/474/1 for more information).

This change just reduces the priority at which these specific messages are logged so they don't 1) swamp the client applications' logs, and 2) make the Application Developer think something is wrong when something expected happens.