### PR TITLE
IBM-Swift/Kitura#869 Set socket processor handler before starting and…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       dist: trusty
       sudo: required
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.1
       sudo: required
 
 before_install:

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -157,7 +157,10 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         response.reset()
         
         // If the IncomingSocketHandler was freed, we can't handle the request
-        guard let handler = handler else { return }
+        guard let handler = handler else {
+            Log.error("IncomingSocketHandler not set or freed before parsing complete")
+            return
+        }
         
         if isUpgrade {
             ConnectionUpgrader.instance.upgradeConnection(handler: handler, request: request, response: response)

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -69,6 +69,7 @@ public class IncomingSocketHandler {
         self.socket = socket
         processor = using
         manager = managedBy
+        processor?.handler = self
         
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
             readerSource = DispatchSource.makeReadSource(fileDescriptor: socket.socketfd,
@@ -80,8 +81,6 @@ public class IncomingSocketHandler {
             readerSource.setCancelHandler(handler: self.handleCancel)
             readerSource.resume()
         #endif
-        
-        processor?.handler = self
     }
     
     /// Read in the available data and hand off to common processing code

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -46,9 +46,8 @@ class LifecycleListenerTests: XCTestCase {
 
         let server = HTTP.createServer()
         server.started {
-            startExpectation.fulfill()
-        }.started {
             started = true
+            startExpectation.fulfill()
         }
 
         do {

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -61,11 +61,17 @@ class MonitoringTests: XCTestCase {
             XCTFail("Server failed to start: \(error)")
         }
         
-        server.listen(port: 8090)
+        do {
+            try server.listen(on: 8090)
         
-        self.waitForExpectations(timeout: 10) { error in
+            self.waitForExpectations(timeout: 10) { error in
+                server.stop()
+                XCTAssertNil(error);
+                Monitor.delegate = nil
+            }
+        } catch let error {
+            XCTFail("Error: \(error)")
             server.stop()
-            XCTAssertNil(error);
             Monitor.delegate = nil
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Set socket processor handler before starting
- Log error in processor when handler is nil
- Add call site line number to XCTestExpectation description
- Change osx image for travis to 8.1

## Motivation and Context
Kitura osx builds are hanging intermittently when IncomingHTTPSocketProcessor finishes parsing before the handler was set and was failing silently. See IBM-Swift/Kitura#869

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
