### PR TITLE
Deprecate urlComponents because of memory leak and compute it when needed

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -51,21 +51,19 @@ public class FastCGIServerRequest : ServerRequest {
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" for the full URL
+    /// Use "urlURL" or "urlComponents" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
     public var urlString : String { return requestUri ?? "" }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" for the full URL
+    /// Use "urlURL" or "urlComponents" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
     public var url : Data { return requestUri?.data(using: .utf8) ?? Data() }
 
     /// The URL from the request as URLComponents
-    @available(*, deprecated, message:
-    "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
     public lazy var urlComponents: URLComponents = { [unowned self] () in
         return URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
     }()

--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -47,22 +47,28 @@ public class FastCGIServerRequest : ServerRequest {
     /// URI Component received from FastCGI
     private var requestUri : String? = nil
 
+    public private(set) var urlURL = URL(string: "http://not_available/")!
+
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
+    /// Use "urlURL" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var urlString : String { return requestUri ?? "" }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
+    /// Use "urlURL" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var url : Data { return requestUri?.data(using: .utf8) ?? Data() }
 
     /// The URL from the request as URLComponents
-    public private(set) var urlComponents = URLComponents()
+    @available(*, deprecated, message:
+    "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
+    public lazy var urlComponents: URLComponents = { [unowned self] () in
+        return URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+    }()
 
     /// Chunk of body read in by the http_parser, filled by callbacks to onBody
     private var bodyChunk = BufferList()
@@ -164,10 +170,10 @@ public class FastCGIServerRequest : ServerRequest {
             Log.error("REQUEST_URI header value not received")
         }
 
-        if let urlComponents = URLComponents(string: url) {
-            self.urlComponents = urlComponents
+        if let urlURL = URL(string: url) {
+            self.urlURL = urlURL
         } else {
-            Log.error("URLComponents init failed from: \(url)")
+            Log.error("URL init failed from: \(url)")
         }
     }
 

--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -51,19 +51,22 @@ public class FastCGIServerRequest : ServerRequest {
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" or "urlComponents" for the full URL
+    /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var urlString : String { return requestUri ?? "" }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" or "urlComponents" for the full URL
+    /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var url : Data { return requestUri?.data(using: .utf8) ?? Data() }
 
     /// The URL from the request as URLComponents
+    /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead
+    @available(*, deprecated, message:
+        "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
     public lazy var urlComponents: URLComponents = { [unowned self] () in
         return URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
     }()

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -49,21 +49,27 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     /// socket signature of the request.
     public var signature: Socket.Signature? { return socket?.signature }
 
-    /// The URL from the request as URLComponents.
-    public private(set) var urlComponents = URLComponents()
+    public private(set) var urlURL = URL(string: "http://not_available/")!
+
+    /// The URL from the request as URLComponents
+    @available(*, deprecated, message:
+    "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
+    public lazy var urlComponents: URLComponents = { [unowned self] () in
+        return URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+    }()
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
+    /// Use "urlURL" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var urlString : String { return String(data: pathAndQueryParams, encoding: .utf8) ?? "" }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
+    /// Use "urlURL" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var url : Data { return pathAndQueryParams }
 
     /// Parsed path and optional query parameters of the request.
@@ -307,10 +313,10 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                 Log.error("Invalid utf8 encoded path received in onURL: \(self.pathAndQueryParams)")
             }
 
-            if let urlComponents = URLComponents(string: url) {
-                self.urlComponents = urlComponents
+            if let urlURL = URL(string: url) {
+                self.urlURL = urlURL
             } else {
-                Log.error("URLComponents init failed from parsed value: \(url)")
+                Log.error("URL init failed from: \(url)")
             }
 
             if let forwardedFor = headers["X-Forwarded-For"]?[0] {
@@ -355,7 +361,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         lastHeaderWasAValue = false
         saveBody = true
         pathAndQueryParams.count = 0
-        urlComponents = URLComponents()
+        urlURL = URL(string: "http://not_available/")!
         headers.removeAll()
         bodyChunk.reset()
         status.reset()

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -52,24 +52,22 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     public private(set) var urlURL = URL(string: "http://not_available/")!
 
     /// The URL from the request as URLComponents
-    @available(*, deprecated, message:
-    "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
     public lazy var urlComponents: URLComponents = { [unowned self] () in
         return URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
     }()
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" for the full URL
+    /// Use "urlURL" or "urlComponents" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
     public var urlString : String { return String(data: pathAndQueryParams, encoding: .utf8) ?? "" }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" for the full URL
+    /// Use "urlURL" or "urlComponents" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
     public var url : Data { return pathAndQueryParams }
 
     /// Parsed path and optional query parameters of the request.
@@ -317,6 +315,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                 self.urlURL = urlURL
             } else {
                 Log.error("URL init failed from: \(url)")
+                self.urlURL = URL(string: "http://not_available/")!
             }
 
             if let forwardedFor = headers["X-Forwarded-For"]?[0] {
@@ -361,7 +360,6 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         lastHeaderWasAValue = false
         saveBody = true
         pathAndQueryParams.count = 0
-        urlURL = URL(string: "http://not_available/")!
         headers.removeAll()
         bodyChunk.reset()
         status.reset()

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -58,10 +58,12 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     @available(*, deprecated, message:
         "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
     public var urlComponents: URLComponents {
-        if urlc == nil {
-            urlc = URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+        if let urlc = self.urlc {
+            return urlc
         }
-        return urlc!
+        let urlc = URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+        self.urlc = urlc
+        return urlc
     }
 
     /// The URL from the request in string form

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -26,19 +26,22 @@ public protocol ServerRequest: class {
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" or "urlComponents" for the full URL
+    /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     var urlString : String { get }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" or "urlComponents" for the full URL
+    /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     var url : Data { get }
 
     /// The URL from the request as URLComponents
+    /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead
+    @available(*, deprecated, message:
+        "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
     var urlComponents : URLComponents { get }
 
     /// The URL from the request

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -26,21 +26,19 @@ public protocol ServerRequest: class {
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" for the full URL
+    /// Use "urlURL" or "urlComponents" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
     var urlString : String { get }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" for the full URL
+    /// Use "urlURL" or "urlComponents" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
     var url : Data { get }
 
     /// The URL from the request as URLComponents
-    @available(*, deprecated, message:
-        "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
     var urlComponents : URLComponents { get }
 
     /// The URL from the request

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -26,20 +26,25 @@ public protocol ServerRequest: class {
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
+    /// Use "urlURL" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     var urlString : String { get }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
+    /// Use "urlURL" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     var url : Data { get }
 
     /// The URL from the request as URLComponents
+    @available(*, deprecated, message:
+        "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
     var urlComponents : URLComponents { get }
+
+    /// The URL from the request
+    var urlURL : URL { get }
 
     /// The IP address of the client
     var remoteAddress: String { get }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Deprecate urlComponents because of memory leak and compute it when needed
- Use urlURL instead

## Motivation and Context
See IBM-Swift/Kitura#901

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.