### PR TITLE
Added basic E2E test for FastCGI and fixed minor typos in FastCGIServer.swift

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -186,7 +186,7 @@ public class FastCGIServer: Server {
                     break
                 default:
                     // we just want to ignore every other status for now
-                    // as they all result in simply closing the conncetion anyways.
+                    // as they all result in simply closing the connection anyways.
                     clientSocket.close()
                     break
                 }
@@ -212,7 +212,7 @@ public class FastCGIServer: Server {
         listenSocket?.close()
     }
 
-    /// Add a new listener for server beeing started
+    /// Add a new listener for server being started
     ///
     /// - Parameter callback: The listener callback that will run on server successfull start-up
     ///
@@ -223,7 +223,7 @@ public class FastCGIServer: Server {
         return self
     }
 
-    /// Add a new listener for server beeing stopped
+    /// Add a new listener for server being stopped
     ///
     /// - Parameter callback: The listener callback that will run when server stops
     ///

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -27,8 +27,7 @@ class ClientE2ETests: XCTestCase {
         return [
             ("testSimpleHTTPClient", testSimpleHTTPClient),
             ("testPostRequests", testPostRequests),
-            ("testErrorRequests", testErrorRequests),
-            ("testFastCGIStates", testFastCGIStates)
+            ("testErrorRequests", testErrorRequests)
         ]
     }
 
@@ -123,38 +122,6 @@ class ClientE2ETests: XCTestCase {
             }
             catch {
                 print("Error reading body or writing response")
-            }
-        }
-    }
-    
-    func testFastCGIStates() {
-        let server = FastCGI.createServer()
-        XCTAssertEqual(server.state, ServerState.unknown)
-        do {
-            try server.listen(on: 9000)
-        } catch let error {
-            XCTFail("Error: \(error)")
-            server.stop()
-        }
-        
-        let startedExpectation = self.expectation(description: "Start server")
-        server.started(callback: {
-            XCTAssertEqual(server.state, ServerState.started)
-            let stoppedExpectation = self.expectation(description: "Stop server")
-            server.stopped(callback: {
-                XCTAssertEqual(server.state, ServerState.stopped)
-                stoppedExpectation.fulfill()
-            })
-            server.stop()
-            startedExpectation.fulfill()
-        })
-        
-        waitForExpectations(timeout: 5) { error in
-            if let error = error {
-                if (server.state == ServerState.started) {
-                    server.stop()
-                }
-                XCTFail("Timeout error: \(error)")
             }
         }
     }

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -27,7 +27,8 @@ class ClientE2ETests: XCTestCase {
         return [
             ("testSimpleHTTPClient", testSimpleHTTPClient),
             ("testPostRequests", testPostRequests),
-            ("testErrorRequests", testErrorRequests)
+            ("testErrorRequests", testErrorRequests),
+            ("testFastCGIStates", testFastCGIStates)
         ]
     }
 
@@ -122,6 +123,38 @@ class ClientE2ETests: XCTestCase {
             }
             catch {
                 print("Error reading body or writing response")
+            }
+        }
+    }
+    
+    func testFastCGIStates() {
+        let server = FastCGI.createServer()
+        XCTAssertEqual(server.state, ServerState.unknown)
+        do {
+            try server.listen(on: 9000)
+        } catch let error {
+            XCTFail("Error: \(error)")
+            server.stop()
+        }
+        
+        let startedExpectation = self.expectation(description: "Start server")
+        server.started(callback: {
+            XCTAssertEqual(server.state, ServerState.started)
+            let stoppedExpectation = self.expectation(description: "Stop server")
+            server.stopped(callback: {
+                XCTAssertEqual(server.state, ServerState.stopped)
+                stoppedExpectation.fulfill()
+            })
+            server.stop()
+            startedExpectation.fulfill()
+        })
+        
+        waitForExpectations(timeout: 5) { error in
+            if let error = error {
+                if (server.state == ServerState.started) {
+                    server.stop()
+                }
+                XCTFail("Timeout error: \(error)")
             }
         }
     }


### PR DESCRIPTION
## Description
Added a test that starts and stops a server, and checks that the states are as expected.

## Motivation and Context
There is currently a much lower test coverage % in FastCGI than in other parts of Kitura-Net. The existing FastCGI tests focus on the FastCGI protocols.

## How Has This Been Tested?
A new test has been created, and it is successful