### PR TITLE
Fix a memory leak that occurs with keep alive

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -118,8 +118,8 @@ public class HTTPServerResponse : ServerResponse {
             if !keepAlive && !processor.isUpgrade {
                 processor.close()
             }
+            Monitor.delegate?.finished(request: processor.request, response: self)
         }
-        Monitor.delegate?.finished(request: processor?.request, response: self)
     }
 
     /// Begin flushing the buffer


### PR DESCRIPTION
Fix a memory leak that occurs when sockets kept open due to keep alive are finally closed due to inactivity.

## Description
When sockets are closed due to inactivity make sure that the IncomingSocketProcessor.prepareToClose() function is called. This will break the retain loop between the HTTPIncomingMesage and the HTTPParser.

## Motivation and Context
Fixes a memory lak reported in isuue IBM-Swift/Kitura#902

## How Has This Been Tested?
@djones tested using Safari and determined that the memory leak was fixed.
Ran KituraNet unit tests on macOS and Linux.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
