### PR TITLE
Report the real port number if asked to listen on port 0

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -67,10 +67,20 @@ public class HTTPServer: Server {
 
             try socket.listen(on: port, maxBacklogSize: maxPendingConnections)
 
+            // If a random (ephemeral) port number was requested, get the listening port
+            let listeningPort = Int(socket.listeningPort)
+            if listeningPort != port {
+                self.port = listeningPort
+                // We should only expect a different port if the requested port was zero.
+                if port != 0 {
+                    Log.error("Listening port \(listeningPort) does not match requested port \(port)")
+                }
+            }
+
             if let delegate = socket.delegate {
-                Log.info("Listening on port \(port) (delegate: \(delegate))")
+                Log.info("Listening on port \(self.port!) (delegate: \(delegate))")
             } else {
-                Log.info("Listening on port \(port)")
+                Log.info("Listening on port \(self.port!)")
             }
 
             let queuedBlock = DispatchWorkItem(block: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It is possible to ask Kitura to listen on port 0.  The resulting behavior is that the listening socket will be bound to a system-assigned port number in the ephemeral port range (as expected).

At the moment, Kitura does not check what port was actually bound, so reports that the server is listening on port 0.  Applications cannot query the port number to find out which one was assigned.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Follows a conversation with @tunniclm. Enables API Connect to create instances of servers without having to find a free port in advance (which creates a timing window).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I ran a hello world test with logging set to `.info` and a port number of `0`. The actual port number is printed to the log message rather than `0`.
- I was able to obtain the port number from `HTTPServer.port`.
- The Kitura-net tests passed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

