### PR TITLE
Fixes and improvements to the Connection Upgrade support

### DIFF
--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -37,7 +37,7 @@ extension KituraNetTest {
         //       sleep(10)
     }
 
-    func performServerTest(_ delegate: ServerDelegate, line: Int = #line, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
+    func performServerTest(_ delegate: ServerDelegate?, line: Int = #line, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
         let server = HTTP.createServer()
         server.delegate = delegate
 

--- a/Tests/KituraNetTests/UpgradeTests.swift
+++ b/Tests/KituraNetTests/UpgradeTests.swift
@@ -47,7 +47,7 @@ class UpgradeTests: XCTestCase {
     func testNoRegistrations() {
         ConnectionUpgrader.clear()
         
-        performServerTest(TestServerDelegate()) { expectation in
+        performServerTest(nil) { expectation in
             
             guard let socket = self.sendUpgradeRequest(forProtocol: "testing") else { return }
 
@@ -70,7 +70,7 @@ class UpgradeTests: XCTestCase {
             closedSocketExpectation.fulfill()
         })
         
-        performServerTest(TestServerDelegate()) { expectation in
+        performServerTest(nil) { expectation in
             
             guard let socket = self.sendUpgradeRequest(forProtocol: "testing") else { return }
             
@@ -107,7 +107,7 @@ class UpgradeTests: XCTestCase {
         ConnectionUpgrader.clear()
         ConnectionUpgrader.register(factory: TestingProtocolSocketProcessorFactory())
         
-        performServerTest(TestServerDelegate()) { expectation in
+        performServerTest(nil) { expectation in
             
             guard let socket = self.sendUpgradeRequest(forProtocol: "testing123") else { return }
             
@@ -181,13 +181,6 @@ class UpgradeTests: XCTestCase {
             XCTFail("Failed to send upgrade request. Error=\(error)")
         }
         return (errorFlag ? nil : response, unparsedData)
-    }
-    
-    class TestServerDelegate : ServerDelegate {
-        
-        func handle(request: ServerRequest, response: ServerResponse) {
-            XCTFail("Server deelgate invoked in an Upgrade scenario")
-        }
     }
     
     // A very simple `ConnectionUpgradeFactory` class for testing


### PR DESCRIPTION
This PR provides a set of fixes and improvements to the processing of HTTP 1.1 Connection Upgrade requests. In particular:

   1) A correction was made to the way the body is sent if an upgrade request fails.
   2) An internal API was added to enable other parts of KituraNet to determine if any ConnectionUpgraders were registered.
   3) If the user did not specify a ServerDelegate for a HTTPServer and there are ConnectionUpgraders registered, a dummy ServerDelegate will be used. The dummy ServerDelegate returns 404 for any requests it received.
This enables a server to be set up that will use protocols other than HTTP without the user needing to create a ServerDelegate or use Kitura. 

   4) The above functionality is now used in the unit tests for the ConnectionUpgrader.

## Motivation and Context
1) Fix problems with the existing code.
2) Enable Servers that will only use a protocol other than HTTP to run without a ServerDelegate.

## How Has This Been Tested?
The KituraNet unit tests were run on macOS and Linux

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have updated tests to cover my changes.
