### PR TITLE
Eliminate the reference loop between HTTPIncomingMessage and HTTPParser

### DIFF
--- a/Sources/KituraNet/ClientResponse.swift
+++ b/Sources/KituraNet/ClientResponse.swift
@@ -46,10 +46,18 @@ public class ClientResponse: HTTPIncomingMessage {
     /// BufferList instance for storing the response 
     var responseBuffers = BufferList()
     
+    /// Location in buffer to start parsing
+    private var startParsingFrom = 0
+    
     /// Parse the contents of the responseBuffers
     func parse() -> HTTPParserStatus {
         let buffer = NSMutableData()
+        responseBuffers.rewind()
         _ = responseBuffers.fill(data: buffer)
-        return super.parse(buffer)
+        let parseStatus = super.parse(buffer, from: startParsingFrom)
+        
+        startParsingFrom = buffer.length - parseStatus.bytesLeft
+        
+        return parseStatus
     }
 }

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -66,15 +66,12 @@ public class HTTPIncomingMessage {
         return urlc
     }
     
-    // Delete when urlString is removed
-    private var _urlString = ""
-
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
         "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
-    public var urlString : String { return _urlString }
+    public var urlString : String { return httpParser.urlString }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -23,28 +23,28 @@ import Foundation
 // MARK: IncomingMessage
 
 /// A representation of HTTP incoming message.
-public class HTTPIncomingMessage : HTTPParserDelegate {
+public class HTTPIncomingMessage {
 
-    /// Major version for HTTP of the incoming message.
-    public private(set) var httpVersionMajor: UInt16?
-
-    /// Minor version for HTTP of the incoming message.
-    public private(set) var httpVersionMinor: UInt16?
-    
     /// HTTP Status code if this message is a response
     public private(set) var httpStatusCode: HTTPStatusCode = .unknown
-
-    /// Set of HTTP headers of the incoming message.
-    public var headers = HeadersContainer()
-
-    /// HTTP Method of the incoming message.
-    public private(set) var method: String = "" 
 
     /// is a request? (or a response)
     public let isRequest: Bool
 
     /// Client connection socket
     private let socket: Socket?
+    
+    /// HTTP Method of the incoming message.
+    public var method: String { return httpParser.method }
+    
+    /// Major version of HTTP of the request
+    public var httpVersionMajor: UInt16? { return httpParser.httpVersionMajor }
+    
+    /// Minor version of HTTP of the request
+    public var httpVersionMinor: UInt16? { return httpParser.httpVersionMinor }
+    
+    /// Set of HTTP headers of the incoming message.
+    public var headers: HeadersContainer { return httpParser.headers }
 
     /// socket signature of the request.
     public var signature: Socket.Signature? { return socket?.signature }
@@ -65,54 +65,36 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         self.urlc = urlc
         return urlc
     }
+    
+    // Delete when urlString is removed
+    private var _urlString = ""
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
         "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
-    public var urlString : String { return String(data: pathAndQueryParams, encoding: .utf8) ?? "" }
+    public var urlString : String { return _urlString }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
         "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
-    public var url : Data { return pathAndQueryParams }
-
-    /// Parsed path and optional query parameters of the request.
-    private var pathAndQueryParams = Data()
-
-    /// Indicates if the parser should save the message body and call onBody()
-    var saveBody = true
+    public var url : Data { return Data(bytes: httpParser.url.bytes, count: httpParser.url.length) }
 
     // Private
     
     /// Default buffer size used for creating a BufferList
     private static let bufferSize = 2000
 
-    /// State of callbacks from parser WRT headers
-    private var lastHeaderWasAValue = false
-
-    /// Bytes of a header key that was just parsed and returned in chunks by the pars
-    private let lastHeaderField = NSMutableData()
-
-    /// Bytes of a header value that was just parsed and returned in chunks by the parser
-    private let lastHeaderValue = NSMutableData()
-
     /// The http_parser Swift wrapper
-    private var httpParser: HTTPParser?
+    private var httpParser: HTTPParser!
 
     /// State of incoming message handling
     private var status = HTTPParserStatus()
 
-    /// Chunk of body read in by the http_parser, filled by callbacks to onBody
-    private var bodyChunk = BufferList()
-
-    private var ioBuffer = Data(capacity: HTTPIncomingMessage.bufferSize)
-    
     private var buffer = Data(capacity: HTTPIncomingMessage.bufferSize)
-    
     
     /// Initializes a new IncomingMessage
     ///
@@ -123,24 +105,17 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         self.isRequest = isRequest
         self.socket = socket
         httpParser = HTTPParser(isRequest: isRequest)
-
-        httpParser!.delegate = self
     }
 
     /// Parse the message
     ///
     /// - Parameter buffer: An NSData object contaning the data to be parsed
-    func parse (_ buffer: NSData) -> HTTPParserStatus {
-        guard let parser = httpParser else {
-            status.error = .internalError
-            return status
-        }
-        
-        var length = buffer.length
+    /// - Parameter from: From where in the buffer to start parsing
+    func parse (_ buffer: NSData, from: Int) -> HTTPParserStatus {
+        let length = buffer.length - from
         
         guard length > 0  else {
             /* Handle unexpected EOF. Usually just close the connection. */
-            release()
             status.error = .unexpectedEOF
             return status
         }
@@ -150,29 +125,22 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
             reset()
         }
         
-        var start = 0
-        while status.state != .messageComplete  &&  status.error == nil  &&  length > 0  {
-            let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self) + start
-            let (numberParsed, upgrade) = parser.execute(bytes, length: length)
-            if upgrade == 1 {
-                status.upgrade = true
-            }
-            else if  numberParsed != length  {
-                
-                if  self.status.state == .reset  {
-                    // Apparently the short message was a Continue. Let's just keep on parsing
-                    start = numberParsed
-                    self.reset()
-                }
-                else {
-                    /* Handle error. Usually just close the connection. */
-                    self.release()
-                    self.status.error = .parsedLessThanRead
-                }
-            }
-            length -= numberParsed
+        let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self) + from
+        let (numberParsed, upgrade) = httpParser.execute(bytes, length: length)
+        
+        if httpParser.completed {
+            parsingCompleted()
         }
-        status.bytesLeft = length
+        else if numberParsed != length  {
+            /* Handle error. Usually just close the connection. */
+            status.error = .parsedLessThanRead
+        }
+        
+        if upgrade == 1 {
+            status.upgrade = true
+        }
+        
+        status.bytesLeft = length - numberParsed
         
         return status
     }
@@ -183,7 +151,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
     /// - Throws: if an error occurs while reading the body.
     /// - Returns: the number of bytes read.
     public func read(into data: inout Data) throws -> Int {
-        let count = bodyChunk.fill(data: &data)
+        let count = httpParser.bodyChunk.fill(data: &data)
         return count
     }
 
@@ -218,84 +186,9 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
         }
     }
 
-    /// Free the httpParser from the IncomingMessage
-    private func freeHTTPParser () {
-        httpParser?.delegate = nil
-        httpParser = nil
-    }
-
-    /// Instructions for when reading URL portion
-    ///
-    /// - Parameter bytes: The bytes of the parsed URL
-    /// - Parameter count: The number of bytes parsed
-    func onURL(_ bytes: UnsafePointer<UInt8>, count: Int) {
-        pathAndQueryParams.append(bytes, count: count)
-    }
-
-    /// Instructions for when reading header key
-    ///
-    /// - Parameter bytes: The bytes of the parsed header key
-    /// - Parameter count: The number of bytes parsed
-    func onHeaderField (_ bytes: UnsafePointer<UInt8>, count: Int) {
+    /// Extra handling performed when a message is completely parsed
+    func parsingCompleted() {
         
-        if lastHeaderWasAValue {
-            addHeader()
-        }
-        lastHeaderField.append(bytes, length: count)
-
-        lastHeaderWasAValue = false
-        
-    }
-
-    /// Instructions for when reading a header value
-    ///
-    /// - Parameter bytes: The bytes of the parsed header value
-    /// - Parameter count: The number of bytes parsed
-    func onHeaderValue (_ bytes: UnsafePointer<UInt8>, count: Int) {
-        lastHeaderValue.append(bytes, length: count)
-
-        lastHeaderWasAValue = true
-    }
-
-    /// Set the header key-value pair
-    private func addHeader() {
-
-        var zero: CChar = 0
-        lastHeaderField.append(&zero, length: 1)
-        let headerKey = String(cString: lastHeaderField.bytes.assumingMemoryBound(to: CChar.self))
-        lastHeaderValue.append(&zero, length: 1)
-        let headerValue = String(cString: lastHeaderValue.bytes.assumingMemoryBound(to: CChar.self))
-        
-        headers.append(headerKey, value: headerValue)
-
-        lastHeaderField.length = 0
-        lastHeaderValue.length = 0
-
-    }
-
-    /// Instructions for when reading the body of the message
-    ///
-    /// - Parameter bytes: The bytes of the parsed body
-    /// - Parameter count: The number of bytes parsed
-    func onBody (_ bytes: UnsafePointer<UInt8>, count: Int) {
-        self.bodyChunk.append(bytes: bytes, length: count)
-
-    }
-
-    /// Instructions for when the headers have been finished being parsed.
-    ///
-    /// - Parameter method: the HTTP method
-    /// - Parameter versionMajor: major version of HTTP
-    /// - Parameter versionMinor: minor version of HTTP
-    func onHeadersComplete(method: String, versionMajor: UInt16, versionMinor: UInt16) {
-        
-        httpVersionMajor = versionMajor
-        httpVersionMinor = versionMinor
-        self.method = method
-        if  lastHeaderWasAValue  {
-            addHeader()
-        }
-
         if isRequest {
             var url = ""
             var proto: String?
@@ -314,12 +207,7 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
                 Log.error("Host header not received")
             }
 
-            if let pathAndQueryParams = String(data: self.pathAndQueryParams, encoding: .utf8) {
-                url.append(pathAndQueryParams)
-            } else {
-                url.append("/")
-                Log.error("Invalid utf8 encoded path received in onURL: \(self.pathAndQueryParams)")
-            }
+            url.append(httpParser.urlString)
 
             if let urlURL = URL(string: url) {
                 self.urlURL = urlURL
@@ -329,36 +217,19 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
             }
             self.urlc = nil // reset it so it is recomputed on next access
 
-            if let forwardedFor = headers["X-Forwarded-For"]?[0] {
-                Log.verbose("HTTP request forwarded for=\(forwardedFor); proto=\(headers["X-Forwarded-Proto"]?[0] ?? "N.A."); by=\(socket?.remoteHostname ?? "N.A.");")
-            } else {
-                Log.verbose("HTTP request from=\(socket?.remoteHostname ?? "N.A."); proto=\(proto ?? "N.A.");")
+            if Log.isLogging(.verbose) {
+                if let forwardedFor = headers["X-Forwarded-For"]?[0] {
+                    Log.verbose("HTTP request forwarded for=\(forwardedFor); proto=\(headers["X-Forwarded-Proto"]?[0] ?? "N.A."); by=\(socket?.remoteHostname ?? "N.A.");")
+                } else {
+                    Log.verbose("HTTP request from=\(socket?.remoteHostname ?? "N.A."); proto=\(proto ?? "N.A.");")
+                }
             }
         }
 
-        status.keepAlive = httpParser?.isKeepAlive() ?? false
-        status.state = .headersComplete
-        
-        httpStatusCode = httpParser?.statusCode ?? .unknown
-    }
-
-    /// Instructions for when beginning to read a message
-    func onMessageBegin() {
-    }
-
-    /// Instructions for when done reading the message
-    func onMessageComplete() {
-        
-        status.keepAlive = httpParser?.isKeepAlive() ?? false
+        status.keepAlive = httpParser.isKeepAlive() 
         status.state = .messageComplete
-        if  !status.keepAlive  {
-            release()
-        }
-    }
-    
-    /// Signal that the connection is being closed, and resources should be freed
-    func release() {
-        freeHTTPParser()
+        
+        httpStatusCode = httpParser.statusCode
     }
 
     /// Signal that reading is being reset
@@ -368,11 +239,6 @@ public class HTTPIncomingMessage : HTTPParserDelegate {
 
     /// When we're ready, really reset everything
     private func reset() {
-        lastHeaderWasAValue = false
-        saveBody = true
-        pathAndQueryParams.count = 0
-        headers.removeAll()
-        bodyChunk.reset()
         status.reset()
         httpParser?.reset()
     }

--- a/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParserStatus.swift
@@ -20,7 +20,6 @@ import Foundation
 enum HTTPParserState {
     
     case initial
-    case headersComplete
     case messageComplete
     case reset
 }

--- a/Sources/KituraNet/HTTPParser/ParseResults.swift
+++ b/Sources/KituraNet/HTTPParser/ParseResults.swift
@@ -1,0 +1,143 @@
+/*
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// class to hold results of callbacks from the http_parser
+class ParseResults {
+    /// Have the parsing completed? (MessageComplete)
+    var completed = false
+    
+    /// HTTP Method of the incoming message.
+    private(set) var method = ""
+    
+    /// URL path and query string from request
+    let url = NSMutableData(capacity: 2000) ?? NSMutableData()
+    
+    /// URL path and query string from request in String form
+    var urlString = ""
+    
+    /// Major version for HTTP of the incoming message.
+    private(set) var httpVersionMajor: UInt16 = 0
+    
+    /// Minor version for HTTP of the incoming message.
+    private(set) var httpVersionMinor: UInt16 = 0
+    
+    /// Set of HTTP headers of the incoming message.
+    var headers = HeadersContainer()
+    
+    /// State of callbacks from parser WRT headers
+    private var lastHeaderWasAValue = false
+    
+    /// Bytes of a header key that was just parsed and returned in chunks by the pars
+    private let lastHeaderField = NSMutableData()
+    
+    /// Bytes of a header value that was just parsed and returned in chunks by the parser
+    private let lastHeaderValue = NSMutableData()
+    
+    /// Chunk of body read in by the http_parser, filled by callbacks to onBody
+    private(set) var bodyChunk = BufferList()
+    
+    init() {}
+    
+    /// Callback for when a piece of the body of the message was parsed
+    ///
+    /// - Parameter bytes: The bytes of the parsed body
+    /// - Parameter count: The number of bytes parsed
+    func onBody (_ bytes: UnsafePointer<UInt8>, count: Int) {
+        bodyChunk.append(bytes: bytes, length: count)
+    }
+    
+    /// Callback for when the headers have been finished being parsed.
+    ///
+    /// - Parameter method: the HTTP method
+    /// - Parameter versionMajor: major version of HTTP
+    /// - Parameter versionMinor: minor version of HTTP
+    func onHeadersComplete(method: String, versionMajor: UInt16, versionMinor: UInt16) {
+        httpVersionMajor = versionMajor
+        httpVersionMinor = versionMinor
+        self.method = method
+        if  lastHeaderWasAValue  {
+            addHeader()
+        }
+        
+        var zero: CChar = 0
+        url.append(&zero, length: 1)
+        urlString = String(cString: url.bytes.assumingMemoryBound(to: CChar.self))
+        url.length -= 1
+    }
+    
+    /// Callback for when a piece of a header key was parsed
+    ///
+    /// - Parameter bytes: The bytes of the parsed header key
+    /// - Parameter count: The number of bytes parsed
+    func onHeaderField (_ bytes: UnsafePointer<UInt8>, count: Int) {
+        
+        if lastHeaderWasAValue {
+            addHeader()
+        }
+        lastHeaderField.append(bytes, length: count)
+        
+        lastHeaderWasAValue = false
+        
+    }
+    
+    /// Callback for when a piece of a header value was parsed
+    ///
+    /// - Parameter bytes: The bytes of the parsed header value
+    /// - Parameter count: The number of bytes parsed
+    func onHeaderValue (_ bytes: UnsafePointer<UInt8>, count: Int) {
+        lastHeaderValue.append(bytes, length: count)
+        
+        lastHeaderWasAValue = true
+    }
+    
+    /// Callback for when the HTTP message is completely parsed
+    func onMessageComplete() {
+        completed = true
+    }
+    
+    /// Instructions for when reading URL portion
+    ///
+    /// - Parameter bytes: The bytes of the parsed URL
+    /// - Parameter count: The number of bytes parsed
+    func onURL(_ bytes: UnsafePointer<UInt8>, count: Int) {
+        url.append(bytes, length: count)
+    }
+    
+    func reset() {
+        completed = false
+        lastHeaderWasAValue = false
+        bodyChunk.reset()
+        headers.removeAll()
+        url.length = 0
+    }
+    
+    /// Set the header key-value pair
+    private func addHeader() {
+        var zero: CChar = 0
+        lastHeaderField.append(&zero, length: 1)
+        let headerKey = String(cString: lastHeaderField.bytes.assumingMemoryBound(to: CChar.self))
+        lastHeaderValue.append(&zero, length: 1)
+        let headerValue = String(cString: lastHeaderValue.bytes.assumingMemoryBound(to: CChar.self))
+        
+        headers.append(headerKey, value: headerValue)
+        
+        lastHeaderField.length = 0
+        lastHeaderValue.length = 0
+        
+    }
+}

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -22,7 +22,7 @@ import Foundation
 public protocol ServerRequest: class {
     
     /// The set of headers received with the incoming request
-    var headers : HeadersContainer { get set }
+    var headers : HeadersContainer { get }
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'

--- a/Tests/KituraNetTests/MiscellaneousTests.swift
+++ b/Tests/KituraNetTests/MiscellaneousTests.swift
@@ -48,9 +48,6 @@ class MiscellaneousTests: XCTestCase {
     func testHTTPIncomingMessage() {
         let message = HTTPIncomingMessage(isRequest: true)
         
-        XCTAssertEqual(message.parse(NSData()).error, HTTPParserErrorType.unexpectedEOF, "Parse should have errored with error=\(HTTPParserErrorType.unexpectedEOF)")
-        
-        message.release()
-        XCTAssertEqual(message.parse(NSData()).error, HTTPParserErrorType.internalError, "Parse should have errored with error=\(HTTPParserErrorType.internalError)")
+        XCTAssertEqual(message.parse(NSData(), from: 0).error, HTTPParserErrorType.unexpectedEOF, "Parse should have errored with error=\(HTTPParserErrorType.unexpectedEOF)")
     }
 }

--- a/Tests/KituraNetTests/UpgradeTests.swift
+++ b/Tests/KituraNetTests/UpgradeTests.swift
@@ -160,7 +160,7 @@ class UpgradeTests: XCTestCase {
                 let count = try socket.read(into: buffer)
 
                 if count != 0 {
-                    let parserStatus = response.parse(buffer)
+                    let parserStatus = response.parse(buffer, from: 0)
 
                     if parserStatus.state == .messageComplete {
                         keepProcessing = false


### PR DESCRIPTION
## Description
HTTPParser needs an object to receive the results of the callbacks from the C language http_parser. Unfortunately self can't be used in creating these callbacks. Instead an inner object is created in HTTPParser for receiving callback results from C language http_parser. HTTPParser provides accessor functions for the values stored in the inner object.

## Motivation and Context
Solve all sorts of potential memory leaks due to reference loops.

## How Has This Been Tested?
KituraNet unit tests have been run along with memory leak tests.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
