### PR TITLE
Undeprecate ServerRequest.url

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -59,8 +59,6 @@ public class FastCGIServerRequest : ServerRequest {
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
-    @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var url : Data { return requestUri?.data(using: .utf8) ?? Data() }
 
     /// The URL from the request as URLComponents

--- a/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
+++ b/Sources/KituraNet/HTTP/HTTPIncomingMessage.swift
@@ -110,8 +110,6 @@ public class HTTPIncomingMessage {
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
-    @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var url : Data { return Data(bytes: httpParser.url.bytes, count: httpParser.url.length) }
 
     // Private

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -34,8 +34,6 @@ public protocol ServerRequest: class {
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
-    @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     var url : Data { get }
 
     /// The URL from the request as URLComponents

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -237,6 +237,7 @@ class ClientE2ETests: XCTestCase {
         func handle(request: ServerRequest, response: ServerResponse) {
             XCTAssertEqual(request.urlURL.path, urlPath, "Path in request.urlURL wasn't \(urlPath), it was \(request.urlURL.port)")
             XCTAssertEqual(request.urlURL.port, 8090, "The port in request.urlURL wasn't 8090, it was \(request.urlURL.port)")
+            XCTAssertEqual(request.url, urlPath.data(using: .utf8))
             do {
                 response.statusCode = .OK
                 let result = "OK"

--- a/Tests/KituraNetTests/FastCGIRequestTests.swift
+++ b/Tests/KituraNetTests/FastCGIRequestTests.swift
@@ -314,6 +314,7 @@ class FastCGIRequestTests: XCTestCase {
             XCTAssertEqual(request.urlURL.scheme, "HTTP", "Expected a scheme of HTTP, it was \(request.urlURL.scheme)")
             XCTAssertEqual(request.urlURL.port, 8090, "Expected a port of 8090, it was \(request.urlURL.port)")
             XCTAssertEqual(request.urlURL.path, "/hello", "Expected a path of /hello, it was \(request.urlURL.path)")
+            XCTAssertEqual(request.url, "/hello".data(using: .utf8))
             do {
                 response.statusCode = .OK
                 let result = "OK"


### PR DESCRIPTION
We have temporarily undeprecated ServerRequest.url, due to the performance issues discovered when using URL

## Motivation and Context
Performance issues as seen in IBM-Swift/Kitura#942 

## How Has This Been Tested?
Ran KituraNet unit tests

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
