### PR TITLE
Fix static file serving of large files

### DIFF
--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -97,7 +97,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
             result = parseStartingFrom == 0
             
         case .messageCompletelyRead:
-            result = parseStartingFrom == 0 && parseStartingFrom == buffer.length
+            result = parseStartingFrom == 0 && 0 == buffer.length
             break
         }
         

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -97,7 +97,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
             result = parseStartingFrom == 0
             
         case .messageCompletelyRead:
-            result = parseStartingFrom == 0 && 0 == buffer.length
+            result = parseStartingFrom == 0 && buffer.length == 0
             break
         }
         

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -83,6 +83,8 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     ///
     /// - Returns: true if the data was processed, false if it needs to be processed later.
     public func process(_ buffer: NSData) -> Bool {
+        let result: Bool
+        
         switch(state) {
         case .reset:
             request.prepareToReset()
@@ -92,12 +94,14 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         case .initial:
             inProgress = true
             parse(buffer)
+            result = parseStartingFrom == 0
             
         case .messageCompletelyRead:
+            result = parseStartingFrom == 0 && parseStartingFrom == buffer.length
             break
         }
         
-        return parseStartingFrom == 0
+        return result
     }
     
     /// Write data to the socket


### PR DESCRIPTION
Fix the static file serving of large files which was broken when driven by wrk.

## Description
Larger files (or body payloads in general) are sent as at least two writes to the socket. One for the header stuff and the rest of them for the body. When wrk sees the headers and they include Connection: keepalive, a new request is sent before the body of the response of the previous request is read.

There was a bug in the way data in the read buffer that arrived after a request was completed parsed, was handled.

This fix correctly marks that data as data that needs to be processed later on.

## Motivation and Context
Fix issues in static file serving tests

## How Has This Been Tested?
@djones verified it with a test bucket he has.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
