### PR TITLE
Guard socket read(), write(), close() race conditions and use SSL tests

### DIFF
--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -318,10 +318,7 @@ public class IncomingSocketHandler {
     /// - Note: On OSX the cancel handler will actually close the socket.
     private func close() {
         guard !writeInProgress && !readInProgress else {
-            Log.warning("Deferring handler close. writeInProgress:\(writeInProgress) readInProgress:\(readInProgress)")
-            IncomingSocketHandler.socketWriterQueue.sync() { [unowned self] in
-                self.close()
-            }
+            Log.warning("Skipping socket close. writeInProgress:\(writeInProgress) readInProgress:\(readInProgress)")
             return
         }
 

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -229,7 +229,7 @@ public class IncomingSocketHandler {
             #endif
         }
         
-        if preparingToClose && writeBuffer.length == writeBufferPosition {
+        if preparingToClose && writeBuffer.length == writeBufferPosition && !writeInProgress && !readInProgress {
             close()
         }
     }
@@ -306,7 +306,7 @@ public class IncomingSocketHandler {
         if !preparingToClose {
             preparingToClose = true
             
-            if writeBuffer.length == writeBufferPosition {
+            if writeBuffer.length == writeBufferPosition && !writeInProgress && !readInProgress {
                 close()
             }
         }
@@ -317,11 +317,6 @@ public class IncomingSocketHandler {
     /// - Note: On Linux closing the socket causes it to be dropped by epoll.
     /// - Note: On OSX the cancel handler will actually close the socket.
     private func close() {
-        guard !writeInProgress && !readInProgress else {
-            Log.warning("Skipping socket close. writeInProgress:\(writeInProgress) readInProgress:\(readInProgress)")
-            return
-        }
-
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
             readerSource.cancel()
         #else

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -24,7 +24,7 @@ import SSLService
 
 class KituraNetTest: XCTestCase {
 
-    static let useSSLDefault = false
+    static let useSSLDefault = true
     static let portDefault = 8090
 
     var useSSL = useSSLDefault


### PR DESCRIPTION
## Description
- Add state guards for IncomingSocketHandler read() write() and close() functions
- Make sure we don't close sockets while they're being used or try to use them after they're closed
- Make most unit tests use SSLService as it surfaces race condition problems whereas Socket mostly ignores them

## Motivation and Context
IBM-Swift/Kitura#959
IBM-Swift/Kitura#962

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
