### PR TITLE
Reset the parser every time ClientResponse.parse() is called.

### DIFF
--- a/Sources/KituraNet/ClientResponse.swift
+++ b/Sources/KituraNet/ClientResponse.swift
@@ -54,6 +54,13 @@ public class ClientResponse: HTTPIncomingMessage {
         let buffer = NSMutableData()
         responseBuffers.rewind()
         _ = responseBuffers.fill(data: buffer)
+        
+        // There can be multiple responses in the responseBuffers, if a Continue response
+        // was received from the server. Each call to this function parses a single
+        // response, starting from the prior parse call, if any, left off. when this
+        // happens, the http_parser needs to be reset between invocations.
+        prepareToReset()
+        
         let parseStatus = super.parse(buffer, from: startParsingFrom, completeBuffer: true)
         
         startParsingFrom = buffer.length - parseStatus.bytesLeft


### PR DESCRIPTION
## Description

Some servers send Continue responses when POST and PUT requests are made prior to sending the "real" response of the POST or PUT request. KituraNet.ClientRequest reads all of the responses it receives and then invokes KituraNet.ClientResponse.parse() to parse them. They are parsed one at a time and the http_parser needs to be reset between invocations. This fix adds back the needed http_parser reset.

## Motivation and Context
Fix issue IBM-Swift/Kitura-CouchDB#51

## How Has This Been Tested?
Installed CouchDB 2.0 on a mac and ran the Kitura-CouchDB unit tests. Without this fix, the update hangs. With this fix the tests run to completion on both macOS and Linux.

In addition I ran the KituraNet unit tests on both macOS and Linux.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
