### PR TITLE
IBM-Swift/Kitura#982 Avoid forced unwrapping in tests

### DIFF
--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -50,10 +50,10 @@ class ClientE2ETests: KituraNetTest {
     func testHeadRequests() {
         performServerTest(delegate) { expectation in
             self.performRequest("head", path: "/headtest", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 do {
                     var data = Data()
-                    let count = try response!.readAllData(into: &data)
+                    let count = try response?.readAllData(into: &data)
                     XCTAssertEqual(count, 0, "Result should have been zero bytes, was \(count) bytes")
                 }
                 catch {
@@ -69,7 +69,7 @@ class ClientE2ETests: KituraNetTest {
             let server = try HTTPServer.listen(on: 0, delegate: delegate)
             _ = HTTP.get("http://localhost:\(server.port!)") { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
             }
             server.stop()
         } catch let error {
@@ -80,20 +80,22 @@ class ClientE2ETests: KituraNetTest {
     func testSimpleHTTPClient() {
         _ = HTTP.get("http://www.ibm.com") {response in
             XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-            XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-            let contentType = response!.headers["Content-Type"]
+            XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+            let contentType = response?.headers["Content-Type"]
             XCTAssertNotNil(contentType, "No ContentType header in response")
-            XCTAssertEqual(contentType!, ["text/html"], "Content-Type header wasn't `text/html`")
+            if let contentType = contentType {
+                XCTAssertEqual(contentType, ["text/html"], "Content-Type header wasn't `text/html`")
+            }
         }
     }
     
     func testPostRequests() {
         performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("post", path: "/posttest", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 do {
                     var data = Data()
-                    let count = try response!.readAllData(into: &data)
+                    let count = try response?.readAllData(into: &data)
                     XCTAssertEqual(count, 12, "Result should have been 12 bytes, was \(count) bytes")
                     let postValue = String(data: data as Data, encoding: .utf8)
                     if  let postValue = postValue {
@@ -111,10 +113,10 @@ class ClientE2ETests: KituraNetTest {
         },
         { expectation in
             self.performRequest("post", path: "/posttest", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 do {
                     var data = Data()
-                    let count = try response!.readAllData(into: &data)
+                    let count = try response?.readAllData(into: &data)
                     XCTAssertEqual(count, 13, "Result should have been 13 bytes, was \(count) bytes")
                     let postValue = String(data: data as Data, encoding: .utf8)
                     if  let postValue = postValue {
@@ -138,10 +140,10 @@ class ClientE2ETests: KituraNetTest {
     func testPutRequests() {
         performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("put", path: "/puttest", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 do {
                     var data = Data()
-                    let count = try response!.readAllData(into: &data)
+                    let count = try response?.readAllData(into: &data)
                     XCTAssertEqual(count, 12, "Result should have been 12 bytes, was \(count) bytes")
                     let putValue = String(data: data as Data, encoding: .utf8)
                     if  let putValue = putValue {
@@ -159,10 +161,10 @@ class ClientE2ETests: KituraNetTest {
         },
         { expectation in
             self.performRequest("put", path: "/puttest", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 do {
                     var data = Data()
-                    let count = try response!.readAllData(into: &data)
+                    let count = try response?.readAllData(into: &data)
                     XCTAssertEqual(count, 13, "Result should have been 13 bytes, was \(count) bytes")
                     let postValue = String(data: data as Data, encoding: .utf8)
                     if  let postValue = postValue {
@@ -185,7 +187,7 @@ class ClientE2ETests: KituraNetTest {
     func testErrorRequests() {
         performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("plover", path: "/xzzy", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.badRequest, "Status code wasn't .badrequest was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "Status code wasn't .badrequest was \(response?.statusCode)")
                 expectation.fulfill()
             })
         })
@@ -194,7 +196,7 @@ class ClientE2ETests: KituraNetTest {
     func testUrlURL() {
         performServerTest(TestURLDelegate()) { expectation in
             self.performRequest("post", path: ClientE2ETests.urlPath, callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 expectation.fulfill()
             })
         }

--- a/Tests/KituraNetTests/FastCGIProtocolTests.swift
+++ b/Tests/KituraNetTests/FastCGIProtocolTests.swift
@@ -171,7 +171,7 @@ class FastCGIProtocolTests: KituraNetTest {
             XCTAssert(parser.data != nil, "No data was received")
             
             if parser.data != nil {
-                XCTAssert(testData == parser.data!, "Data received was not data sent.")
+                XCTAssert(testData == parser.data, "Data received was not data sent.")
             }
             
         }

--- a/Tests/KituraNetTests/HTTPResponseTests.swift
+++ b/Tests/KituraNetTests/HTTPResponseTests.swift
@@ -32,30 +32,30 @@ class HTTPResponseTests: KituraNetTest {
         headers.append("Content-Type", value: "text/html")
         var values = headers["Content-Type"]
         XCTAssertNotNil(values, "Couldn't retrieve just set Content-Type header")
-        XCTAssertEqual(values!.count, 1, "Content-Type header should only have one value")
-        XCTAssertEqual(values![0], "text/html")
+        XCTAssertEqual(values?.count, 1, "Content-Type header should only have one value")
+        XCTAssertEqual(values?[0], "text/html")
         
         headers.append("Content-Type", value: "text/plain; charset=utf-8")
-        XCTAssertEqual(headers["Content-Type"]![0], "text/html")
+        XCTAssertEqual(headers["Content-Type"]?[0], "text/html")
         
         headers["Content-Type"] = nil
         XCTAssertNil(headers["Content-Type"])
         
         headers.append("Content-Type", value: "text/plain, image/png")
-        XCTAssertEqual(headers["Content-Type"]![0], "text/plain, image/png")
+        XCTAssertEqual(headers["Content-Type"]?[0], "text/plain, image/png")
         
         headers.append("Content-Type", value: "text/html, image/jpeg")
-        XCTAssertEqual(headers["Content-Type"]![0], "text/plain, image/png")
+        XCTAssertEqual(headers["Content-Type"]?[0], "text/plain, image/png")
         
         headers.append("Content-Type", value: "charset=UTF-8")
-        XCTAssertEqual(headers["Content-Type"]![0], "text/plain, image/png")
+        XCTAssertEqual(headers["Content-Type"]?[0], "text/plain, image/png")
         
         headers["Content-Type"] = nil
         
         headers.append("Content-Type", value: "text/html")
-        XCTAssertEqual(headers["Content-Type"]![0], "text/html")
+        XCTAssertEqual(headers["Content-Type"]?[0], "text/html")
         
         headers.append("Content-Type", value: "image/png, text/plain")
-        XCTAssertEqual(headers["Content-Type"]![0], "text/html")
+        XCTAssertEqual(headers["Content-Type"]?[0], "text/html")
     }
 }

--- a/Tests/KituraNetTests/LargePayloadTests.swift
+++ b/Tests/KituraNetTests/LargePayloadTests.swift
@@ -44,11 +44,11 @@ class LargePayloadTests: KituraNetTest {
         performServerTest(delegate, useSSL: false, asyncTasks: { expectation in
             let payload = "[" + contentTypesString + "," + contentTypesString + contentTypesString + "," + contentTypesString + "]"
             self.performRequest("post", path: "/largepost", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 do {
                     let expectedResult = "Read \(payload.characters.count) bytes"
                     var data = Data()
-                    let count = try response!.readAllData(into: &data)
+                    let count = try response?.readAllData(into: &data)
                     XCTAssertEqual(count, expectedResult.characters.count, "Result should have been \(expectedResult.characters.count) bytes, was \(count) bytes")
                     let postValue = String(data: data, encoding: .utf8)
                     if  let postValue = postValue {
@@ -72,7 +72,7 @@ class LargePayloadTests: KituraNetTest {
         performServerTest(delegate, useSSL: false, asyncTasks: { expectation in
             // This test is NOT using self.performRequest, in order to test an extra signature of HTTP.request
             let request = HTTP.request("http://localhost:\(self.port)/largepost") {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 expectation.fulfill()
             }
             request.end()

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -54,7 +54,7 @@ class MonitoringTests: KituraNetTest {
             DispatchQueue.global().async {
                 self.performRequest("get", path: "/plover", callback: { response in
                     XCTAssertNotNil(response, "Received a nil response")
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response!.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(response?.statusCode)")
                 })
             }
         }

--- a/Tests/KituraNetTests/ParserTests.swift
+++ b/Tests/KituraNetTests/ParserTests.swift
@@ -31,20 +31,20 @@ class ParserTests: KituraNetTest {
     func testParseSimpleUrl() {
         let url = "https://example.org/absolute/URI/with/absolute/path/to/resource.txt".data(using: .utf8)!
         let urlParser = URLParser(url: url, isConnect: false)
-        XCTAssertEqual(urlParser.schema!, "https", "Incorrect schema")
-        XCTAssertEqual(urlParser.host!, "example.org", "Incorrect host")
-        XCTAssertEqual(urlParser.path!, "/absolute/URI/with/absolute/path/to/resource.txt", "Incorrect path")
+        XCTAssertEqual(urlParser.schema, "https", "Incorrect schema")
+        XCTAssertEqual(urlParser.host, "example.org", "Incorrect host")
+        XCTAssertEqual(urlParser.path, "/absolute/URI/with/absolute/path/to/resource.txt", "Incorrect path")
     }
     
     func testParseComplexUrl() {
         let url = "abc://username:password@example.com:123/path/data?key=value&key1=value1#fragid1".data(using: .utf8)!
         let urlParser = URLParser(url: url, isConnect: false)
-        XCTAssertEqual(urlParser.schema!, "abc", "Incorrect schema")
-        XCTAssertEqual(urlParser.host!, "example.com", "Incorrect host")
-        XCTAssertEqual(urlParser.path!, "/path/data", "Incorrect path")
-        XCTAssertEqual(urlParser.port!, 123, "Incorrect port")
-        XCTAssertEqual(urlParser.fragment!, "fragid1", "Incorrect fragment")
-        XCTAssertEqual(urlParser.userinfo!, "username:password", "Incorrect userinfo")
+        XCTAssertEqual(urlParser.schema, "abc", "Incorrect schema")
+        XCTAssertEqual(urlParser.host, "example.com", "Incorrect host")
+        XCTAssertEqual(urlParser.path, "/path/data", "Incorrect path")
+        XCTAssertEqual(urlParser.port, 123, "Incorrect port")
+        XCTAssertEqual(urlParser.fragment, "fragid1", "Incorrect fragment")
+        XCTAssertEqual(urlParser.userinfo, "username:password", "Incorrect userinfo")
         XCTAssertEqual(urlParser.queryParameters["key"], "value", "Incorrect query")
         XCTAssertEqual(urlParser.queryParameters["key1"], "value1", "Incorrect query")
     }


### PR DESCRIPTION
## Description
There is a lot of forced unwrapping (mostly response related references) in tests which causes a crash when the test fails and the reference is nil. This causes test execution to terminate and subsequent tests to not be run.

We should be able to fix most of the issues by either just removing the forced unwrapping or replacing it with optional chaining, but may require some additional logic in a few cases.

## Motivation and Context
IBM-Swift/Kitura#982

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
