### PR TITLE
Stop IncomingSocketManager epoll tasks on server stop

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -88,9 +88,11 @@ public class HTTPServer: Server {
                 Log.info("Listening on port \(self.port!)")
             }
 
+            // set synchronously to avoid contention in back to back server start/stop calls
+            self.state = .started
+            self.lifecycleListener.performStartCallbacks()
+
             let queuedBlock = DispatchWorkItem(block: {
-                self.state = .started
-                self.lifecycleListener.performStartCallbacks()
                 self.listen(listenSocket: socket, socketManager: socketManager)
                 self.lifecycleListener.performStopCallbacks()
             })

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -42,9 +42,6 @@ public class HTTPServer: Server {
     /// Maximum number of pending connections
     private let maxPendingConnections = 100
 
-    /// Incoming socket handler
-    private let socketManager = IncomingSocketManager()
-
     /// SSL cert configs for handling client requests
     public var sslConfig: SSLService.Configuration?
 
@@ -150,6 +147,11 @@ public class HTTPServer: Server {
 
     /// Listen on socket while server is started
     private func listen(listenSocket: Socket) {
+        let socketManager = IncomingSocketManager()
+        defer {
+            socketManager.stop()
+        }
+
         repeat {
             do {
                 let clientSocket = try listenSocket.acceptClientConnection()

--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -82,6 +82,18 @@ public class IncomingSocketManager  {
         }
     #endif
 
+    deinit {
+        stop()
+    }
+
+    /// Stop this socket manager instance and cleanup resources.
+    /// If using epoll, it ends the epoll process() task and releases its thread.
+    public func stop() {
+        #if !GCD_ASYNCH && os(Linux)
+            runEpoll = false
+        #endif
+    }
+
     /// Handle a new incoming socket
     ///
     /// - Parameter socket: the incoming socket to handle

--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -45,7 +45,10 @@ public class IncomingSocketManager  {
     
     /// The last time we checked for an idle socket
     var keepAliveIdleLastTimeChecked = Date()
-    
+
+    /// Flag indicating when we are done using this socket manager, so we can clean up
+    private var stopped = false
+
     #if !GCD_ASYNCH && os(Linux)
         private let maximumNumberOfEvents = 300
     
@@ -55,7 +58,6 @@ public class IncomingSocketManager  {
         private let queues:[DispatchQueue]
 
         let epollTimeout: Int32 = 50
-        var runEpoll = true
 
         private func epollDescriptor(fd:Int32) -> Int32 {
             return epollDescriptors[Int(fd) % numberOfEpollTasks];
@@ -87,10 +89,11 @@ public class IncomingSocketManager  {
     }
 
     /// Stop this socket manager instance and cleanup resources.
-    /// If using epoll, it ends the epoll process() task and releases its thread.
+    /// If using epoll, it also ends the epoll process() task, closes the epoll fd and releases its thread.
     public func stop() {
-        #if !GCD_ASYNCH && os(Linux)
-            runEpoll = false
+        stopped = true
+        #if GCD_ASYNCH || !os(Linux)
+            removeIdleSockets(removeAll: true)
         #endif
     }
 
@@ -99,6 +102,11 @@ public class IncomingSocketManager  {
     /// - Parameter socket: the incoming socket to handle
     /// - Parameter using: The ServerDelegate to actually handle the socket
     public func handle(socket: Socket, processor: IncomingSocketProcessor) {
+        guard !stopped else {
+            Log.warning("Cannot handle socket as socket manager has been stopped")
+            return
+        }
+
         do {
             try socket.setBlocking(mode: false)
             
@@ -129,7 +137,7 @@ public class IncomingSocketManager  {
             var deferredHandlers = [Int32: IncomingSocketHandler]()
             var deferredHandlingNeeded = false
         
-            while  runEpoll  {
+            while !stopped {
                 let count = Int(epoll_wait(epollDescriptor, &pollingEvents, Int32(maximumNumberOfEvents), epollTimeout))
             
                 if  count == -1  {
@@ -176,6 +184,10 @@ public class IncomingSocketManager  {
                     deferredHandlingNeeded = process(deferredHandlers: &deferredHandlers)
                 }
             }
+
+            // cleanup after manager stopped
+            removeIdleSockets(removeAll: true)
+            close(epollDescriptor)
         }
 
         private func process(deferredHandlers: inout [Int32: IncomingSocketHandler]) -> Bool {
@@ -205,13 +217,15 @@ public class IncomingSocketManager  {
     /// to have a lock around the access to the socketHandlers Dictionary. The other
     /// idea here is that if sockets aren't coming in, it doesn't matter too much if
     /// we leave a round some idle sockets.
-    private func removeIdleSockets() {
+    ///
+    /// - Parameter allSockets: flag indicating if the manager is shutting down, and we should cleanup all sockets, not just idle ones
+    private func removeIdleSockets(removeAll: Bool = false) {
         let now = Date()
-        guard  now.timeIntervalSince(keepAliveIdleLastTimeChecked) > keepAliveIdleCheckingInterval  else { return }
+        guard removeAll || now.timeIntervalSince(keepAliveIdleLastTimeChecked) > keepAliveIdleCheckingInterval  else { return }
         
         let maxInterval = now.timeIntervalSinceReferenceDate
         for (fileDescriptor, handler) in socketHandlers {
-            if  handler.processor != nil  &&  (handler.processor!.inProgress  ||  maxInterval < handler.processor!.keepAliveUntil) {
+            if !removeAll && handler.processor != nil  &&  (handler.processor!.inProgress  ||  maxInterval < handler.processor!.keepAliveUntil) {
                 continue
             }
             socketHandlers.removeValue(forKey: fileDescriptor)

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -50,8 +50,12 @@ class KituraNetTest: XCTestCase {
         #endif
     }()
 
-    func doSetUp() {
+    private static let initOnce: () = {
         PrintLogger.use(colored: true)
+    }()
+
+    func doSetUp() {
+        KituraNetTest.initOnce
     }
 
     func doTearDown() {

--- a/Tests/KituraNetTests/SocketManagerTests.swift
+++ b/Tests/KituraNetTests/SocketManagerTests.swift
@@ -37,7 +37,7 @@ class SocketManagerTests: KituraNetTest {
     override func tearDown() {
         #if !GCD_ASYNCH && os(Linux)
             if let manager = manager {
-                manager.runEpoll = false
+                manager.stop()
                 usleep(UInt32(manager.epollTimeout) * UInt32(1000))  /* epollTimeout is in milliseconds */
             }
         #endif


### PR DESCRIPTION
## Description
HTTPServer creates an IncomingSocketManager instance on startup which creates two async epoll tasks and DispatchQueues on linux. These tasks should be terminated when the server stops so the dispatch threads are released. Otherwise for a linux application that does a periodic Kitura.start() and Kitura.stop(), the threads for these tasks are never released.

Also, initialize Log.logger once across all tests to avoid crash (See IBM-Swift/Kitura#996)

## Motivation and Context
See IBM-Swift/Kitura#997

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
