### PR TITLE
IBM-Swift/Kitura#991 Trap SIGPIPE signal

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,4 +33,6 @@ let package = Package(
 #if os(Linux)
     package.dependencies.append(
         .Package(url: "https://github.com/IBM-Swift/CEpoll.git", majorVersion: 0, minor: 1))
+    package.dependencies.append(
+        .Package(url: "https://github.com/IBM-Swift/BlueSignals.git", majorVersion: 0, minor: 9))
 #endif


### PR DESCRIPTION
## Description
Prevent unexpected process termination when the receiver closes their socket while we were trying to write.  Resolves IBM-Swift/Kitura#991

## Motivation and Context
See IBM-Swift/BlueSSLService/issues/13 and IBM-Swift/BlueSSLService/pull/14
Bill and I decided this fix was an application decision and belonged in Kitura, not SSLService.

## How Has This Been Tested?
Ran a perf test which exited with SIGPIPE frequently before when the clients disconnect.  It now logs a message at .info and continues execution.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
