### PR TITLE
Change forced server startup failure to use an invalid port number

### DIFF
--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -149,31 +149,19 @@ class LifecycleListenerTests: KituraNetTest {
 
         let failedCallbackExpectation = self.expectation(description: "failedCallback")
         
-        let firstServer = HTTP.createServer()
-        
-        let secondServer = HTTP.createServer()
-        secondServer.failed(callback: { error in
+        let server = HTTP.createServer()
+        server.failed(callback: { error in
             failedCallbackExpectation.fulfill()
         })
 
         do {
-            try firstServer.listen(on: self.port)
-            
-            DispatchQueue.global().async {
-                do {
-                    try secondServer.listen(on: self.port)
-                } catch {
-                    // Do NOT fail the test here. An error should be thrown....
-                }
-            }
+            try server.listen(on: -1)
         } catch {
-            XCTFail("Error: \(error)")
+            // Do NOT fail the test here. An error should be thrown....
         }
         
         self.waitForExpectations(timeout: 5) { error in
             XCTAssertNil(error)
-            
-            firstServer.stop()
         }
     }
 }

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -157,7 +157,8 @@ class LifecycleListenerTests: KituraNetTest {
         do {
             try server.listen(on: -1)
         } catch {
-            // Do NOT fail the test here. An error should be thrown....
+            // Do NOT fail the test if an error is thrown.
+            // In this test case an error should be thrown.
         }
         
         self.waitForExpectations(timeout: 5) { error in


### PR DESCRIPTION
## Description
A change in BlueSocket enabled listening on the same port in multiple processes/threads.

This has broken one of Kitura-net's LifecycleListenerTests where it was trying to force a server startup failure by listening on the same port in two different threads.

The fix in this issue will instead simply listen on an invalid port (-1).

## Motivation and Context
Fix the broken build

## How Has This Been Tested?
Ran Kitura-net unit tests which were failing before the fix.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
