### PR TITLE
Add test for Mac vs Linux test count. Randomize test order on Linux. …

### DIFF
--- a/Tests/KituraNetTests/VerifyLinuxTestCount.swift
+++ b/Tests/KituraNetTests/VerifyLinuxTestCount.swift
@@ -1,0 +1,86 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#if os(OSX)
+    import XCTest
+    
+    class VerifyLinuxTestCount: XCTestCase {
+        func testVerifyLinuxTestCount() {
+            var linuxCount: Int
+            var darwinCount: Int
+            
+            // ClientE2ETests
+            linuxCount = ClientE2ETests.allTests.count
+            darwinCount = Int(ClientE2ETests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from ClientE2ETests.allTests")
+            
+            // ClientRequestTests
+            linuxCount = ClientRequestTests.allTests.count
+            darwinCount = Int(ClientRequestTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from ClientRequestTests.allTests")
+            
+            // FastCGIProtocolTests
+            linuxCount = FastCGIProtocolTests.allTests.count
+            darwinCount = Int(FastCGIProtocolTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from FastCGIProtocolTests.allTests")
+            
+            // FastCGIRequestTests
+            linuxCount = FastCGIRequestTests.allTests.count
+            darwinCount = Int(FastCGIRequestTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from FastCGIRequestTests.allTests")
+            
+            // HTTPResponseTests
+            linuxCount = HTTPResponseTests.allTests.count
+            darwinCount = Int(HTTPResponseTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from HTTPResponseTests.allTests")
+            
+            // LargePayloadTests
+            linuxCount = LargePayloadTests.allTests.count
+            darwinCount = Int(LargePayloadTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from LargePayloadTests.allTests")
+            
+            // LifecycleListenerTests
+            linuxCount = LifecycleListenerTests.allTests.count
+            darwinCount = Int(LifecycleListenerTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from LifecycleListenerTests.allTests")
+            
+            // MiscellaneousTests
+            linuxCount = MiscellaneousTests.allTests.count
+            darwinCount = Int(MiscellaneousTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from MiscellaneousTests.allTests")
+            
+            // MonitoringTests
+            linuxCount = MonitoringTests.allTests.count
+            darwinCount = Int(MonitoringTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from MonitoringTests.allTests")
+            
+            // ParserTests
+            linuxCount = ParserTests.allTests.count
+            darwinCount = Int(ParserTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from ParserTests.allTests")
+            
+            // SocketManagerTests
+            linuxCount = SocketManagerTests.allTests.count
+            darwinCount = Int(SocketManagerTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from SocketManagerTests.allTests")
+            
+            // UpgradeTests
+            linuxCount = UpgradeTests.allTests.count
+            darwinCount = Int(UpgradeTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from UpgradeTests.allTests")
+        }
+    }
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -15,20 +15,44 @@
  **/
 
 import XCTest
-
+import Glibc
 @testable import KituraNetTests
 
+// http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
+extension MutableCollection where Indices.Iterator.Element == Index {
+    mutating func shuffle() {
+        let c = count
+        guard c > 1 else { return }
+        
+        srand(UInt32(time(nil)))
+        for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
+            let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
+            guard d != 0 else { continue }
+            let i = index(firstUnshuffled, offsetBy: d)
+            swap(&self[firstUnshuffled], &self[i])
+        }
+    }
+}
+
+extension Sequence {
+    func shuffled() -> [Iterator.Element] {
+        var result = Array(self)
+        result.shuffle()
+        return result
+    }
+}
+
 XCTMain([
-       testCase(ClientE2ETests.allTests),
-       testCase(ClientRequestTests.allTests),
-       testCase(FastCGIProtocolTests.allTests),
-       testCase(FastCGIRequestTests.allTests),
-       testCase(HTTPResponseTests.allTests),
-       testCase(LargePayloadTests.allTests),
-       testCase(LifecycleListenerTests.allTests),
-       testCase(MiscellaneousTests.allTests),
-       testCase(MonitoringTests.allTests),
-       testCase(ParserTests.allTests),
-       testCase(SocketManagerTests.allTests),
-       testCase(UpgradeTests.allTests)
-])
+       testCase(ClientE2ETests.allTests.shuffled()),
+       testCase(ClientRequestTests.allTests.shuffled()),
+       testCase(FastCGIProtocolTests.allTests.shuffled()),
+       testCase(FastCGIRequestTests.allTests.shuffled()),
+       testCase(HTTPResponseTests.allTests.shuffled()),
+       testCase(LargePayloadTests.allTests.shuffled()),
+       testCase(LifecycleListenerTests.allTests.shuffled()),
+       testCase(MiscellaneousTests.allTests.shuffled()),
+       testCase(MonitoringTests.allTests.shuffled()),
+       testCase(ParserTests.allTests.shuffled()),
+       testCase(SocketManagerTests.allTests.shuffled()),
+       testCase(UpgradeTests.allTests.shuffled())
+].shuffled())


### PR DESCRIPTION
…IBM-Swift/Kitura#1056

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added a test class that checks if every other test class has included all their tests in their `allTests` var
- Added extensions in `LinuxMain.swift` to shuffle an array, and shuffle the order that the test classes are run, as well as the tests within the classes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IBM-Swift/Kitura#1056

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Mac and Linux Swift 3.1

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
