### PR TITLE
Minor changes to the protocol upgrade process

### DIFF
--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -62,6 +62,8 @@ public struct ConnectionUpgrader {
             return
         }
         
+        let statusCode = response.statusCode
+        
         var oldProcessor: IncomingSocketProcessor?
         var processor: IncomingSocketProcessor?
         var responseBody: String?
@@ -94,7 +96,9 @@ public struct ConnectionUpgrader {
                     oldProcessor?.inProgress = false
                 }
                 else {
-                    response.statusCode = .badRequest
+                    if response.statusCode == statusCode {
+                        response.statusCode = .badRequest
+                    }
                 }
             }
             if let theBody = responseBody {

--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -91,7 +91,6 @@ public struct ConnectionUpgrader {
                     response.headers["Upgrade"] = [theProtocolName]
                     response.headers["Connection"] = ["Upgrade"]
                     oldProcessor = handler.processor
-                    theProcessor.handler = handler
                     handler.processor = theProcessor
                     oldProcessor?.inProgress = false
                 }
@@ -107,6 +106,7 @@ public struct ConnectionUpgrader {
                 try response.write(from: theBody)
             }
             try response.end()
+            processor?.handler = handler
         }
         catch {
             Log.error("Failed to send response to Upgrade request")


### PR DESCRIPTION
## Description
This PR includes some minor changes for better support of HTTP/2. This includes enabling the ConnectionUpgraderFactory to set the ServerResponse statusCode as well as setting the IncomingSocktHandler into the IncomingSocketProcessor ater the response was sent, thus enables the IncomingSocketProcessor to know that the response was sent.

## Motivation and Context
Support HTTP/2, which sends a different HTTP status code on failure as well needs the ability to send data tot he client immediately after the protocolUpgraded response was sent.

## How Has This Been Tested?
A test was added for the ability to set the response status code when upgrades fail.
Tests have been run on macOS and Linux

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
