### PR TITLE
Add a public contractor to HeadersContainer to make it usable outside of KituraNet

### DIFF
--- a/Sources/KituraNet/HeadersContainer.swift
+++ b/Sources/KituraNet/HeadersContainer.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2015
+ * Copyright IBM Corporation 2015, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ public class HeadersContainer {
     /// The header storage
     internal var headers: [String: (key: String, value: [String])] = [:]
     
+    /// Create an instance of `HeadersContainer`
+    public init() {}
+
     /// Access the value of a HTTP header using subscript syntax.
     ///
     /// - Parameter key: The HTTP header key


### PR DESCRIPTION
## Motivation and Context
Fix issue IBM-Swift/Kitura-WebSocket#12.

See issue IBM-Swift/Kitura#1087

## How Has This Been Tested?
Ran KituraNet unit tests on macOS and Linux

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
