### PR TITLE
Added the ability to send a body of an arbitrary mime type with the response of an Upgrade request

### DIFF
--- a/Sources/KituraNet/ConnectionUpgradeFactory.swift
+++ b/Sources/KituraNet/ConnectionUpgradeFactory.swift
@@ -36,3 +36,26 @@ public protocol ConnectionUpgradeFactory {
     ///        needs to add special headers to the response.
     func upgrade(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) -> (IncomingSocketProcessor?, String?)
 }
+
+extension ConnectionUpgradeFactory {
+    /// "Upgrade" a connection to the protocol supported by this `ConnectionUpgradeFactory`.
+    ///
+    /// - Parameter handler: The `IncomingSocketHandler` that is handling the connection being upgraded.
+    /// - Parameter request: The `ServerRequest` object of the incoming "upgrade" request.
+    /// - Parameter response: The `ServerResponse` object that will be used to send the response of the "upgrade" request.
+    ///
+    /// - Returns: A tuple of the created `IncomingSocketProcessor`, a message to send as the body of the response to
+    ///           the upgrade request, and the mime-type of the message. The `IncomingSocketProcessor` should be nil if the upgrade request wasn't successful.
+    ///           If the message is nil, the response will not contain a body.
+    ///
+    /// - Note: The `ConnectionUpgradeFactory` instance doesn't need to work with the `ServerResponse` unless it
+    ///        needs to add special headers to the response.
+    func upgrade(handler: IncomingSocketHandler, request: ServerRequest, response: ServerResponse) -> (IncomingSocketProcessor?, Data?, String?) {
+        let (processor, responseText) = upgrade(handler: handler, request: request, response: response)
+        
+        if let responseText = responseText {
+            return (processor, responseText.data(using: .utf8), "text/plain")
+        }
+        return (processor, nil, nil)
+    }
+}


### PR DESCRIPTION
## Description
The HTTP/2 upgrade factory needs to send binary data in the response to an upgrade request. The existing API doesn't support that. The new API adds the ability to the ConnectionUpgradeFactory.upgrade function to return an optional Data (the body's contents) and an optional String (the body's mime type). A protocol extension was written to avoid breaking existing APIs.

## Motivation and Context
Needed for HTTP/2 support

## How Has This Been Tested?
Ran unit tests on macOS and Linux.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
