### PR TITLE
Corrected send the Content-Length in KituraNet.ClientRequest if the request is a PUT

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -373,9 +373,7 @@ public class ClientRequest {
             curlHelperSetOptInt(handle!, CURLOPT_SSL_VERIFYHOST, 0)
             curlHelperSetOptInt(handle!, CURLOPT_SSL_VERIFYPEER, 0)
         }
-        setMethod()
-        let count = writeBuffers.count
-        curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, count)
+        setMethodAndContentLength()
         setupHeaders()
         curlHelperSetOptString(handle!, CURLOPT_COOKIEFILE, "")
 
@@ -383,17 +381,20 @@ public class ClientRequest {
         //curlHelperSetOptInt(handle, CURLOPT_VERBOSE, 1)
     }
 
-    /// Sets the HTTP method in libCurl to the one specified in method
-    private func setMethod() {
+    /// Sets the HTTP method and Content-Length in libCurl
+    private func setMethodAndContentLength() {
 
         let methodUpperCase = method.uppercased()
+        let count = writeBuffers.count
         switch(methodUpperCase) {
             case "GET":
                 curlHelperSetOptBool(handle!, CURLOPT_HTTPGET, CURL_TRUE)
             case "POST":
                 curlHelperSetOptBool(handle!, CURLOPT_POST, CURL_TRUE)
+                curlHelperSetOptInt(handle!, CURLOPT_POSTFIELDSIZE, count)
             case "PUT":
-                curlHelperSetOptBool(handle!, CURLOPT_PUT, CURL_TRUE)
+                curlHelperSetOptBool(handle!, CURLOPT_UPLOAD, CURL_TRUE)
+                curlHelperSetOptInt(handle!, CURLOPT_INFILESIZE, count)
             case "HEAD":
                 curlHelperSetOptBool(handle!, CURLOPT_NOBODY, CURL_TRUE)
             default:

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -29,8 +29,8 @@ class ClientE2ETests: KituraNetTest {
             ("testErrorRequests", testErrorRequests),
             ("testHeadRequests", testHeadRequests),
             ("testKeepAlive", testKeepAlive),
-            ("testPostRequests", testPutRequests),
-            ("testPutRequests", testPostRequests),
+            ("testPostRequests", testPostRequests),
+            ("testPutRequests", testPutRequests),
             ("testSimpleHTTPClient", testSimpleHTTPClient),
             ("testUrlURL", testUrlURL)
         ]


### PR DESCRIPTION
## Description
When sending a PUT request via libCurl the Contnt-Length needs to sent differently depending on whether the request is a POST or a PUT. The existing code sent the Content-Length the same way for both POSTs and PUTs. 

## Motivation and Context
Correct issue IBM-Swift/Kitura#1098.

## How Has This Been Tested?
Kitura unit tests were run on both macOS and Linux.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
