### PR TITLE
HTTP/2 Support in ClientRequest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", majorVersion: 1, minor: 7),
         .Package(url: "https://github.com/IBM-Swift/BlueSocket.git", majorVersion: 0, minor: 12),
-        .Package(url: "https://github.com/ymesika/CCurl.git", majorVersion: 0, minor: 2),
+        .Package(url: "https://github.com/IBM-Swift/CCurl.git", majorVersion: 0, minor: 2),
         .Package(url: "https://github.com/IBM-Swift/BlueSSLService.git", majorVersion: 0, minor: 12)
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", majorVersion: 1, minor: 7),
         .Package(url: "https://github.com/IBM-Swift/BlueSocket.git", majorVersion: 0, minor: 12),
-        .Package(url: "https://github.com/IBM-Swift/CCurl.git", majorVersion: 0, minor: 2),
+        .Package(url: "https://github.com/ymesika/CCurl.git", majorVersion: 0, minor: 2),
         .Package(url: "https://github.com/IBM-Swift/BlueSSLService.git", majorVersion: 0, minor: 12)
     ]
 )

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -72,7 +72,13 @@ public class ClientRequest {
 	
 	/// Should HTTP/2 protocol be used
 	private var useHTTP2 = false
-    
+	
+	/// Data that represents the "HTTP/2 " header status line prefix
+	fileprivate static let Http2StatusLineVersion = "HTTP/2 ".data(using: .utf8)!
+	
+	/// Data that represents the "HTTP/2.0 " header status line prefix
+	fileprivate static let Http2StatusLineVersionWithMinor = "HTTP/2.0 ".data(using: .utf8)!
+	
     /// Client request option enum
     public enum Options {
         
@@ -363,7 +369,7 @@ public class ClientRequest {
             }
             
             httpStatusCode = response!.httpStatusCode
-        } while httpStatusCode == .continue
+        } while httpStatusCode == .continue || httpStatusCode == .switchingProtocols
         
         self.callback(self.response)
     }
@@ -449,7 +455,28 @@ extension ClientRequest: CurlInvokerDelegate {
         let count = writeBuffers.fill(buffer: UnsafeMutableRawPointer(buf).assumingMemoryBound(to: UInt8.self), length: size)
         return count
         
-    }
+	}
+	
+	/// libCurl callback to recieve header sent by the server
+	fileprivate func curlHeaderCallback(_ buf: UnsafeMutablePointer<Int8>, size: Int) -> Int {
+		// If the header status line begins with 'HTTP/2 ' we replace it with 'HTTP/2.0' because
+		// otherwise the CHTTPParser will parse this line incorrectly and won't extract the status code
+		ClientRequest.Http2StatusLineVersion.withUnsafeBytes() { (ptr: UnsafePointer<UInt8>) -> Void in
+			if memcmp(ptr, buf, ClientRequest.Http2StatusLineVersion.count) == 0 {
+				ClientRequest.Http2StatusLineVersionWithMinor.withUnsafeBytes() { (p: UnsafePointer<UInt8>) -> Void in
+					response?.responseBuffers.append(bytes: p, length: ClientRequest.Http2StatusLineVersionWithMinor.count)
+					response?.responseBuffers.append(bytes: UnsafeRawPointer(buf).assumingMemoryBound(to: UInt8.self) + ClientRequest.Http2StatusLineVersion.count,
+					                                 length: size - ClientRequest.Http2StatusLineVersion.count)
+				}
+			}
+			else {
+				response?.responseBuffers.append(bytes: UnsafeRawPointer(buf).assumingMemoryBound(to: UInt8.self), length: size)
+			}
+		}
+		
+		return size
+		
+	}
 
     /// libCurl callback invoked when a redirect is about to be done
     fileprivate func prepareForRedirect() {
@@ -535,7 +562,13 @@ private class CurlInvoker {
 
                 let p = privateData?.assumingMemoryBound(to: CurlInvokerDelegate.self).pointee
                 return (p?.curlWriteCallback(buf!, size: size*nMemb))!
-        }
+		}
+		
+		curlHelperSetOptHeaderFunc(handle, ptr) { (buf: UnsafeMutablePointer<Int8>?, size: Int, nMemb: Int, privateData: UnsafeMutableRawPointer?) -> Int in
+			
+				let p = privateData?.assumingMemoryBound(to: CurlInvokerDelegate.self).pointee
+				return (p?.curlHeaderCallback(buf!, size: size*nMemb))!
+		}
     }
     
 }
@@ -546,6 +579,7 @@ private protocol CurlInvokerDelegate: class {
     
     func curlWriteCallback(_ buf: UnsafeMutablePointer<Int8>, size: Int) -> Int
     func curlReadCallback(_ buf: UnsafeMutablePointer<Int8>, size: Int) -> Int
+	func curlHeaderCallback(_ buf: UnsafeMutablePointer<Int8>, size: Int) -> Int
     func prepareForRedirect()
     
 }

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -69,6 +69,9 @@ public class ClientRequest {
     
     /// Should SSL verification be disabled
     private var disableSSLVerification = false
+	
+	/// Should HTTP/2 protocol be used
+	private var useHTTP2 = false
     
     /// Client request option enum
     public enum Options {
@@ -105,7 +108,10 @@ public class ClientRequest {
         ///
         /// - Note: This is very useful when working with self signed certificates.
         case disableSSLVerification
-        
+		
+		/// If present, the client will try to use HTTP/2 protocol for the connection.
+		case useHTTP2
+		
     }
     
     /// Response callback closure type
@@ -141,7 +147,7 @@ public class ClientRequest {
         for option in options  {
             switch(option) {
 
-                case .method, .headers, .maxRedirects, .disableSSLVerification:
+                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2:
                     // call set() for Options that do not construct the URL
                     set(option)
                 case .schema(var schema):
@@ -196,6 +202,8 @@ public class ClientRequest {
             self.maxRedirects = maxRedirects
         case .disableSSLVerification:
             self.disableSSLVerification = true
+		case .useHTTP2:
+			self.useHTTP2 = true
         }
     }
 
@@ -379,6 +387,10 @@ public class ClientRequest {
 
         // To see the messages sent by libCurl, uncomment the next line of code
         //curlHelperSetOptInt(handle, CURLOPT_VERBOSE, 1)
+		
+		if useHTTP2 {
+			curlHelperSetOptInt(handle!, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0)
+		}
     }
 
     /// Sets the HTTP method and Content-Length in libCurl


### PR DESCRIPTION
## Description
Updates to the ClientRequest so that it can make a connection using HTTP/2 protocol.

## Motivation and Context
In preparation for HTTP/2 support in Kitura we've created a test case that uses the ClientRequest to communicate with a server that supports HTTP/2.
Before these changes the communication has been done over HTTP/1.1 and we had to update the ClientRequest to be able to request over HTTP/2 and parse an upgrade response correctly.

## How Has This Been Tested?
Ran the Kitura-net tests to make sure nothing broke.
A set of additional tests a coming Kitura-HTTP2  package are testing the new functionality.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
