### PR TITLE
IBM-Swift/Kitura#1122 Use weak reference, not unowned in IncomingSock…

### DIFF
--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -76,8 +76,13 @@ public class IncomingSocketManager  {
 
             for i in 0 ..< numberOfEpollTasks {
                 // Only run removeIdleSockets in the first instance of process.
-                queues[i].async() { [unowned self] in self.process(epollDescriptor: self.epollDescriptors[i],
-                                                                   runRemoveIdleSockets: i == 0) }
+                let runRemoveIdleSockets = (i == 0)
+                let epollDescriptor = epollDescriptors[i]
+
+                queues[i].async() { [weak self] in
+                    // server could be stopped and socketManager deallocated before this is run.
+                    self?.process(epollDescriptor: epollDescriptor, runRemoveIdleSockets: runRemoveIdleSockets)
+                }
             }
         }
     #else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use weak reference, not unowned in IncomingSocketManager async block as server could be stopped and socketManager deallocated before it is run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
