### PR TITLE
Fix the build breaks as of late.

### DIFF
--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ public class IncomingSocketManager  {
         do {
             try socket.setBlocking(mode: false)
             
-            let handler = IncomingSocketHandler(socket: socket, using: processor, managedBy: self)
+            let handler = IncomingSocketHandler(socket: socket, using: processor)
             socketHandlers[socket.socketfd] = handler
             
             #if !GCD_ASYNCH && os(Linux)


### PR DESCRIPTION
## Description

Insure that the IncomingSocketProcessor used by an IncomingSocketHandler has the back link to the IncomingSocketHandler initialized before the ReaderSource is resumed.

Also removed an unneeded back link to the InncomingSocketManager.

## Motivation and Context
Fixes broken builds, by eliminating a timing window.

## How Has This Been Tested?
Ran Kitura-net unit tests

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
