### PR TITLE
Replace explicit unwrapping with conditional unwrapping

### DIFF
--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -239,7 +239,7 @@ public class IncomingSocketManager  {
         
         let maxInterval = now.timeIntervalSinceReferenceDate
         for (fileDescriptor, handler) in socketHandlers {
-            if !removeAll && handler.processor != nil  &&  (handler.processor!.inProgress  ||  maxInterval < handler.processor!.keepAliveUntil) {
+            if !removeAll && handler.processor != nil  &&  (handler.processor?.inProgress ?? false  ||  maxInterval < handler.processor?.keepAliveUntil ?? maxInterval) {
                 continue
             }
             socketHandlers.removeValue(forKey: fileDescriptor)


### PR DESCRIPTION
## Description
There is code in IncomingSocketManager that tests if a field is NOT nil and then proceeds to explicitly unwrap it. This turns out to be problematic as the field could be modified in another thread at the same time.

The code was changed to conditionally unwrap the field in question.

## Motivation and Context
Fixes issue IBM-Swift/Kitura-net#209 

## How Has This Been Tested?
The Kitura-net unit tests have been run. Although admittedly this is an intermittent failure.

## Checklist:

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
