### PR TITLE
Temporary workaround for IBM-Swift/Kitura#1034

### DIFF
--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -36,6 +36,9 @@ public class IncomingSocketHandler {
     
     static let socketWriterQueue = DispatchQueue(label: "Socket Writer")
    
+    // This variable is unused. It is a temporary workaround for a rare crash under load
+    // (see: https://github.com/IBM-Swift/Kitura/issues/1034) while a proper fix is
+    // investigated.
     var superfluousOptional:String? = String(repeating: "x", count: 2)
  
     #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -35,7 +35,9 @@ import Socket
 public class IncomingSocketHandler {
     
     static let socketWriterQueue = DispatchQueue(label: "Socket Writer")
-    
+   
+    var superfluousOptional:String? = String(repeating: "x", count: 2)
+ 
     #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
         static let socketReaderQueues = [DispatchQueue(label: "Socket Reader A"), DispatchQueue(label: "Socket Reader B")]
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces an unused variable as the first field of IncomingSocketHandler.  It is a temporary workaround for a rare crash under load while we continue to investigate the issue.

## Motivation and Context
This change appears to prevent the second crash detailed in IBM-Swift/Kitura#1034 from occurring.  I believe that the crash is caused by corruption of an IncomingSocketHandler instance, possibly as consequence of a concurrency problem.  Adding a 'sacrificial' field that is not an Object (and thus not retained / released) seems to be sufficient to avoid this crash and has not (in the testing I have done) introduced any further consequences.

## How Has This Been Tested?
I ran the 'HelloMiddleware' benchmark a number of times.  It crashes around 5/6ths of the time without this change.  With it, I have not yet seen a crash.