### PR TITLE
Add support for Unix sockets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", majorVersion: 1, minor: 7),
         .Package(url: "https://github.com/IBM-Swift/BlueSocket.git", majorVersion: 0, minor: 12),
-        .Package(url: "https://github.com/IBM-Swift/CCurl.git", majorVersion: 0, minor: 4),
+        .Package(url: "https://github.com/adellibovi/CCurl.git", majorVersion: 0, minor: 4),
         .Package(url: "https://github.com/IBM-Swift/BlueSSLService.git", majorVersion: 0, minor: 12)
     ]
 )

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -22,7 +22,7 @@ import PackageDescription
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMinor(from: "1.7.0")),
     .package(url: "https://github.com/IBM-Swift/BlueSocket.git", .upToNextMinor(from: "0.12.0")),
-    .package(url: "https://github.com/IBM-Swift/CCurl.git", .upToNextMinor(from: "0.4.0")),
+    .package(url: "https://github.com/adellibovi/CCurl.git", .upToNextMinor(from: "0.4.2")),
     .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", .upToNextMinor(from: "0.12.0"))
 ]
 

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -72,6 +72,10 @@ public class ClientRequest {
 
     /// Should HTTP/2 protocol be used
     private var useHTTP2 = false
+    
+    /// The Unix socket path used for the request
+    private var socketPath: String? = nil
+
 
     /// Data that represents the "HTTP/2 " header status line prefix
     fileprivate static let Http2StatusLineVersion = "HTTP/2 ".data(using: .utf8)!
@@ -118,6 +122,9 @@ public class ClientRequest {
         /// If present, the client will try to use HTTP/2 protocol for the connection.
         case useHTTP2
         
+        /// If present, the client will connect using the Unix Socket
+        case socketPath(String)
+        
     }
     
     /// Response callback closure type
@@ -153,7 +160,7 @@ public class ClientRequest {
         for option in options  {
             switch(option) {
 
-                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2:
+                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2, .socketPath:
                     // call set() for Options that do not construct the URL
                     set(option)
                 case .schema(var schema):
@@ -210,6 +217,8 @@ public class ClientRequest {
             self.disableSSLVerification = true
         case .useHTTP2:
             self.useHTTP2 = true
+        case .socketPath(let socketPath):
+            self.socketPath = socketPath
         }
     }
 
@@ -396,6 +405,10 @@ public class ClientRequest {
 		
         if useHTTP2 {
             curlHelperSetOptInt(handle!, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0)
+        }
+        
+        if let socketPath = socketPath?.cString(using: .utf8) {
+            curlHelperSetUnixSocketPath(handle!, UnsafePointer(socketPath))
         }
     }
 


### PR DESCRIPTION
## Description
This PR add a new case for the ClientRequest.Options which is `socketPath(String)`

## Motivation and Context
It resolves issues #212 

## How Has This Been Tested?
NA

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.