### PR TITLE
IBM-Swift/Kitura#1143 Invoke socket delegate onAccept on a separate thread

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -224,7 +224,7 @@ public class HTTPServer: Server {
     
     private func initializeClientConnection(clientSocket: Socket, listenSocket: Socket, socketManager: IncomingSocketManager) {
         do {
-            try listenSocket.invokeDelegateOnAccept(socket: clientSocket)
+            try listenSocket.invokeDelegateOnAccept(for: clientSocket)
             #if os(Linux)
                 let negotiatedProtocol = clientSocket.delegate?.negotiatedAlpnProtocol ?? "http/1.1"
             #else

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -221,10 +221,16 @@ public class HTTPServer: Server {
             stop()
         }
     }
-    
+
+    /// Initializes a newly accepted client connection.
+    /// This procedure may involve reading bytes from the client (in the case of an SSL handshake),
+    /// so must be done on a separate thread to avoid blocking the listener (Kitura issue #1143).
+    ///
     private func initializeClientConnection(clientSocket: Socket, listenSocket: Socket, socketManager: IncomingSocketManager) {
         do {
-            try listenSocket.invokeDelegateOnAccept(for: clientSocket)
+            if let _ = listenSocket.delegate {
+                try listenSocket.invokeDelegateOnAccept(for: clientSocket)
+            }
             #if os(Linux)
                 let negotiatedProtocol = clientSocket.delegate?.negotiatedAlpnProtocol ?? "http/1.1"
             #else

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -188,30 +188,16 @@ public class HTTPServer: Server {
     private func listen(listenSocket: Socket, socketManager: IncomingSocketManager) {
         repeat {
             do {
-                let clientSocket = try listenSocket.acceptClientConnection()
+                let clientSocket = try listenSocket.acceptClientConnection(invokeDelegate: false)
                 Log.debug("Accepted HTTP connection from: " +
                     "\(clientSocket.remoteHostname):\(clientSocket.remotePort)")
 				
-                #if os(Linux)
-                    let negotiatedProtocol = clientSocket.delegate?.negotiatedAlpnProtocol ?? "http/1.1"
-                #else
-                    let negotiatedProtocol = "http/1.1"
-                #endif
-                
-                if let incomingSocketProcessorCreator = HTTPServer.incomingSocketProcessorCreatorRegistry[negotiatedProtocol] {
-                    let serverDelegate = delegate ?? HTTPServer.dummyServerDelegate
-                    let incomingSocketProcessor: IncomingSocketProcessor?
-                    switch incomingSocketProcessorCreator {
-                    case let creator as HTTPIncomingSocketProcessorCreator:
-                        incomingSocketProcessor = creator.createIncomingSocketProcessor(socket: clientSocket, using: serverDelegate, keepalive: self.keepAliveState)
-                    default:
-                        incomingSocketProcessor = incomingSocketProcessorCreator.createIncomingSocketProcessor(socket: clientSocket, using: serverDelegate)
+                DispatchQueue.global().async { [weak self] in
+                    if let strongSelf = self {
+                        strongSelf.initializeClientConnection(clientSocket: clientSocket, listenSocket: listenSocket, socketManager: socketManager)
                     }
-                    socketManager.handle(socket: clientSocket, processor: incomingSocketProcessor!)
                 }
-                else {
-                    Log.error("Negotiated protocol \(negotiatedProtocol) not supported on this server")
-                }
+                
             } catch let error {
                 if self.state == .stopped {
                     if let socketError = error as? Socket.Error {
@@ -233,6 +219,47 @@ public class HTTPServer: Server {
         if self.state == .started {
             Log.error("listenSocket closed without stop() being called")
             stop()
+        }
+    }
+    
+    private func initializeClientConnection(clientSocket: Socket, listenSocket: Socket, socketManager: IncomingSocketManager) {
+        do {
+            try listenSocket.invokeDelegateOnAccept(socket: clientSocket)
+            #if os(Linux)
+                let negotiatedProtocol = clientSocket.delegate?.negotiatedAlpnProtocol ?? "http/1.1"
+            #else
+                let negotiatedProtocol = "http/1.1"
+            #endif
+            
+            if let incomingSocketProcessorCreator = HTTPServer.incomingSocketProcessorCreatorRegistry[negotiatedProtocol] {
+                let serverDelegate = delegate ?? HTTPServer.dummyServerDelegate
+                let incomingSocketProcessor: IncomingSocketProcessor?
+                switch incomingSocketProcessorCreator {
+                case let creator as HTTPIncomingSocketProcessorCreator:
+                    incomingSocketProcessor = creator.createIncomingSocketProcessor(socket: clientSocket, using: serverDelegate, keepalive: self.keepAliveState)
+                default:
+                    incomingSocketProcessor = incomingSocketProcessorCreator.createIncomingSocketProcessor(socket: clientSocket, using: serverDelegate)
+                }
+                socketManager.handle(socket: clientSocket, processor: incomingSocketProcessor!)
+            }
+            else {
+                Log.error("Negotiated protocol \(negotiatedProtocol) not supported on this server")
+            }
+        } catch let error {
+            if self.state == .stopped {
+                if let socketError = error as? Socket.Error {
+                    if socketError.errorCode == Int32(Socket.SOCKET_ERR_ACCEPT_FAILED) {
+                        Log.info("Server has stopped listening")
+                    } else {
+                        Log.warning("Socket.Error accepting client connection after server stopped: \(error)")
+                    }
+                } else {
+                    Log.warning("Error accepting client connection after server stopped: \(error)")
+                }
+            } else {
+                Log.error("Error accepting client connection: \(error)")
+                self.lifecycleListener.performClientConnectionFailCallbacks(with: error)
+            }
         }
     }
 

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import Foundation
+import Dispatch
 
 import XCTest
 

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -1,0 +1,135 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+import XCTest
+
+@testable import KituraNet
+import Socket
+import SSLService
+
+class RegressionTests: KituraNetTest {
+    
+    static var allTests : [(String, (RegressionTests) -> () throws -> Void)] {
+        return [
+            ("testIssue1143", testIssue1143),
+        ]
+    }
+    
+    override func setUp() {
+        doSetUp()
+    }
+    
+    override func tearDown() {
+        doTearDown()
+    }
+
+    /// Tests the resolution of Kitura issue 1143: SSL socket listener becomes blocked and
+    /// does not accept further connections if a 'bad' connection is made that then sends
+    /// no data (where the server is waiting on SSL_accept to receive a handshake).
+    func testIssue1143() {
+        do {
+            let server: HTTPServer = try startServer(nil, port: 0, useSSL: true)
+            defer {
+                server.stop()
+            }
+
+            guard let serverPort = server.port else {
+                XCTFail("Server port was not initialized")
+                return
+            }
+            XCTAssertTrue(serverPort != 0, "Ephemeral server port not set")
+            
+            // Queue a server stop operation in 1 second, in case the test hangs (socket listener blocks)
+             let recoveryOperation = DispatchWorkItem {
+                server.stop()
+                XCTFail("Test did not complete (hung), server has been stopped")
+            }
+            DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.seconds(1), execute: recoveryOperation)
+            
+            let badClient = try BadClient()
+            let goodClient = try GoodClient()
+
+            defer {
+                badClient.disconnect()
+                goodClient.disconnect()
+            }
+            
+            /// Connect a 'bad' (non-SSL) client to the server
+            try badClient.connect(serverPort)
+            XCTAssertEqual(badClient.connectedPort, serverPort, "BadClient not connected to expected server port")
+            XCTAssertFalse(badClient.socket.isSecure, "Expected BadClient socket to be insecure")
+            
+            /// Connect a 'good' (SSL enabled) client to the server
+            try goodClient.connect(serverPort)
+            XCTAssertEqual(goodClient.connectedPort, serverPort, "GoodClient not connected to expected server port")
+            XCTAssertTrue(goodClient.socket.isSecure, "Expected GoodClient socket to be secure")
+
+            /// Test succeeded (did not hang)
+            recoveryOperation.cancel()
+            
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    /// A simple client based on BlueSocket, which connects to a port but sends no data
+    struct BadClient {
+        let socket: Socket
+        
+        var connectedPort: Int {
+            return Int(self.socket.remotePort)
+        }
+            
+        init() throws {
+            socket = try Socket.create()
+        }
+        
+        func connect(_ port: Int) throws {
+            try socket.connect(to: "localhost", port: Int32(port))
+        }
+        
+        func disconnect() {
+            socket.close()
+        }
+        
+    }
+
+    /// A simple client based on BlueSSLService, which connects to a port and performs
+    /// an SSL handshake
+    struct GoodClient {
+        let socket: Socket
+        
+        var connectedPort: Int {
+            return Int(self.socket.remotePort)
+        }
+        
+        init() throws {
+            socket = try Socket.create()
+            socket.delegate = try SSLService(usingConfiguration: clientSSLConfig)
+        }
+        
+        func connect(_ port: Int) throws {
+            try socket.connect(to: "localhost", port: Int32(port))
+        }
+        
+        func disconnect() {
+            socket.close()
+        }
+        
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -71,5 +71,6 @@ XCTMain([
     testCase(MonitoringTests.allTests.shuffled()),
     testCase(ParserTests.allTests.shuffled()),
     testCase(SocketManagerTests.allTests.shuffled()),
-    testCase(UpgradeTests.allTests.shuffled())
+    testCase(UpgradeTests.allTests.shuffled()),
+    testCase(RegressionTests.allTests.shuffled())
     ].shuffled())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR decouples the invocation of `delegate?.onAccept()` from `listenerSocket.acceptClientConnection()`, invoking the former in a separate thread.

Note, this depends on IBM-Swift/BlueSocket#85 and the subsequent related changes, tagged in BlueSocket `0.12.67`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves IBM-Swift/Kitura#1143

This avoids blocking the listener thread if a badly-behaved client connects to an SSL-enabled listener, which will block in `SSL_accept` until the client transmits an SSL handshake.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the Kitura-net tests (with Socket branch issue_1143) and they passed.

I tested with a Kitura-based application which uses SSLService, driven under load (50 concurrent clients from wrk) and the application functioned correctly. I tested on both Linux and Mac.

I also verified that, when creating a bad connection (as described above), the listener was no longer prevented from accepting further well-behaved connections.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
