### PR TITLE
Disable port reuse by default

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -50,6 +50,9 @@ public class FastCGIServer: Server {
 
     /// TCP socket used for listening for new connections
     private var listenSocket: Socket?
+    
+    /// Whether or not this server allows port reuse (default: disallowed)
+    private var allowPortReuse: Bool = false
 
     fileprivate let lifecycleListener = ServerLifecycleListener()
 
@@ -74,8 +77,9 @@ public class FastCGIServer: Server {
             let socket = try Socket.create()
             self.listenSocket = socket
 
-            try socket.listen(on: port, maxBacklogSize: maxPendingConnections)
+            try socket.listen(on: port, maxBacklogSize: maxPendingConnections, allowPortReuse: self.allowPortReuse)
             Log.info("Listening on port \(port)")
+            Log.verbose("Options for port \(port): maxPendingConnections: \(maxPendingConnections), allowPortReuse: \(self.allowPortReuse)")
 
             // set synchronously to avoid contention in back to back server start/stop calls
             self.state = .started

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -52,7 +52,7 @@ public class FastCGIServer: Server {
     private var listenSocket: Socket?
     
     /// Whether or not this server allows port reuse (default: disallowed)
-    private var allowPortReuse: Bool = false
+    public var allowPortReuse: Bool = false
 
     fileprivate let lifecycleListener = ServerLifecycleListener()
 

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -44,7 +44,7 @@ public class HTTPServer: Server {
     private var listenSocket: Socket?
 
     /// Whether or not this server allows port reuse (default: disallowed)
-    private var allowPortReuse: Bool = false
+    public var allowPortReuse: Bool = false
 
     /// Maximum number of pending connections
     private let maxPendingConnections = 100

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -43,6 +43,9 @@ public class HTTPServer: Server {
     /// TCP socket used for listening for new connections
     private var listenSocket: Socket?
 
+    /// Whether or not this server allows port reuse (default: disallowed)
+    private var allowPortReuse: Bool = false
+
     /// Maximum number of pending connections
     private let maxPendingConnections = 100
 
@@ -92,7 +95,7 @@ public class HTTPServer: Server {
                 socket.delegate = try SSLService(usingConfiguration: sslConfig);
             }
 
-            try socket.listen(on: port, maxBacklogSize: maxPendingConnections)
+            try socket.listen(on: port, maxBacklogSize: maxPendingConnections, allowPortReuse: self.allowPortReuse)
 
             let socketManager = IncomingSocketManager()
             self.socketManager = socketManager
@@ -116,8 +119,10 @@ public class HTTPServer: Server {
                 #endif
                 
                 Log.info("Listening on port \(self.port!) (delegate: \(delegate))")
+                Log.verbose("Options for port \(self.port!): delegate: \(delegate), maxPendingConnections: \(maxPendingConnections), allowPortReuse: \(self.allowPortReuse)")
             } else {
                 Log.info("Listening on port \(self.port!)")
+                Log.verbose("Options for port \(self.port!): maxPendingConnections: \(maxPendingConnections), allowPortReuse: \(self.allowPortReuse)")
             }
 
             // set synchronously to avoid contention in back to back server start/stop calls

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -26,6 +26,7 @@ class KituraNetTest: XCTestCase {
 
     static let useSSLDefault = true
     static let portDefault = 8080
+    static let portReuseDefault = false
 
     var useSSL = useSSLDefault
     var port = portDefault
@@ -56,28 +57,26 @@ class KituraNetTest: XCTestCase {
     func doTearDown() {
     }
 
-    func startServer(_ delegate: ServerDelegate?, port: Int = portDefault, useSSL: Bool = useSSLDefault) throws -> HTTPServer {
+    func startServer(_ delegate: ServerDelegate?, port: Int = portDefault, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault) throws -> HTTPServer {
         
-        let server: HTTPServer
+        let server = HTTP.createServer()
+        server.delegate = delegate
+        server.allowPortReuse = allowPortReuse
         if useSSL {
-            server = HTTP.createServer()
-            server.delegate = delegate
             server.sslConfig = KituraNetTest.sslConfig
-            try server.listen(on: port)
-        } else {
-            server = try HTTPServer.listen(on: port, delegate: delegate)
         }
+        try server.listen(on: port)
         return server
     }
     
-    func performServerTest(_ delegate: ServerDelegate?, port: Int = portDefault, useSSL: Bool = useSSLDefault,
+    func performServerTest(_ delegate: ServerDelegate?, port: Int = portDefault, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault,
                            line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
 
         do {
             self.useSSL = useSSL
             self.port = port
 
-            let server: HTTPServer = try startServer(delegate, port: port, useSSL: useSSL)
+            let server: HTTPServer = try startServer(delegate, port: port, useSSL: useSSL, allowPortReuse: allowPortReuse)
             defer {
                 server.stop()
             }
@@ -99,13 +98,14 @@ class KituraNetTest: XCTestCase {
         }
     }
 
-    func performFastCGIServerTest(_ delegate: ServerDelegate?, port: Int = portDefault,
+    func performFastCGIServerTest(_ delegate: ServerDelegate?, port: Int = portDefault, allowPortReuse: Bool = portReuseDefault,
                                   line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
 
         do {
             self.port = port
 
             let server = try FastCGIServer.listen(on: port, delegate: delegate)
+            server.allowPortReuse = allowPortReuse
             defer {
                 server.stop()
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Uses the optional parameter `allowPortReuse: Bool` to `Socket.listen()` to disable TCP listener port reuse (sharing) by default (added in `BlueSocket 0.12.74`).

This prevents two or more instances of Kitura from being started listening on the same port,  and is the behaviour that Kitura had up until the end of March (prior to IBM-Swift/BlueSocket#61).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In IBM-Swift/BlueSocket#61 the default port options were changed to allow multiple listeners to share the same port (SO_REUSEPORT).  I raised IBM-Swift/BlueSocket#94 as I felt this could lead to accidental sharing of the port, and an optional param was added to `Socket.listen()` to allow this to be disabled.

### Current behaviour
On Linux, the effect is that you can start multiple (potentially, unrelated) Kitura servers on the same port and they will each receive some of the requests to that port.  On OSX, only the first listener will receive requests, though subsequent servers will appear to start normally.

### Previous behaviour
Prior to the above BlueSocket change, Kitura's behaviour was that subsequent attempts to listen on an occupied port would report:
`[2017-10-11T15:32:38.010Z] [ERROR] [Kitura.swift:91 start()] Error listening on port 8080: Error code: -9992(0x-2708), Address already in use. Use server.failed(callback:) to handle`

Simple servers using `Kitura.run()` and only one listener would then terminate, as there would be no listeners to wait for, and the call to `run()` would return.

I feel that it is more appropriate for Kitura to default to the previous behaviour: not allowing the listener port to be shared.  Sharing could be a useful feature, but should be a conscious decision by the user,  as it presents the risk of unexpected sharing when, for example, an old instance of a server is accidentally left running and the user starts a new one.

The default can be overridden, for example, by calling `HTTP.createServer()` followed by `server.allowPortReuse = true`, and will be exposed via Kitura's `addHTTPServer` / `addFastCGIServer` functions in IBM-Swift/Kitura#1158.

I have not added new API to `Server` to allow the static `HTTPServer.listen()` methods to configure this value.  This could be done later if there is a demand for it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the Kitura-net tests, and they passed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
