### PR TITLE
Allow PATCH requests to send data

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -415,6 +415,10 @@ public class ClientRequest {
                 curlHelperSetOptInt(handle!, CURLOPT_INFILESIZE, count)
             case "HEAD":
                 curlHelperSetOptBool(handle!, CURLOPT_NOBODY, CURL_TRUE)
+            case "PATCH":
+                curlHelperSetOptString(handle!, CURLOPT_CUSTOMREQUEST, methodUpperCase)
+                curlHelperSetOptBool(handle!, CURLOPT_UPLOAD, CURL_TRUE)
+                curlHelperSetOptInt(handle!, CURLOPT_INFILESIZE, count)
             default:
                 curlHelperSetOptString(handle!, CURLOPT_CUSTOMREQUEST, methodUpperCase)
         }

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -31,6 +31,7 @@ class ClientE2ETests: KituraNetTest {
             ("testKeepAlive", testKeepAlive),
             ("testPostRequests", testPostRequests),
             ("testPutRequests", testPutRequests),
+            ("testPatchRequests", testPatchRequests),
             ("testSimpleHTTPClient", testSimpleHTTPClient),
             ("testUrlURL", testUrlURL)
         ]
@@ -161,7 +162,7 @@ class ClientE2ETests: KituraNetTest {
             }
         })
     }
-    
+
     func testPutRequests() {
         performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("put", path: "/puttest", callback: {response in
@@ -194,6 +195,53 @@ class ClientE2ETests: KituraNetTest {
                     let postValue = String(data: data as Data, encoding: .utf8)
                     if  let postValue = postValue {
                         XCTAssertEqual(postValue, "Read 16 bytes")
+                    }
+                    else {
+                        XCTFail("postValue's value wasn't an UTF8 string")
+                    }
+                }
+                catch {
+                    XCTFail("Failed reading the body of the response")
+                }
+                expectation.fulfill()
+            }) {request in
+                request.write(from: "A few characters")
+            }
+        })
+    }    
+
+    func testPatchRequests() {
+        performServerTest(delegate, asyncTasks: { expectation in
+            self.performRequest("patch", path: "/patchtest", callback: {response in
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
+                do {
+                    var data = Data()
+                    let count = try response?.readAllData(into: &data)
+                    XCTAssertEqual(count, 12, "Result should have been 12 bytes, was \(String(describing: count)) bytes")
+                    let patchValue = String(data: data as Data, encoding: .utf8)
+                    if  let patchValue = patchValue {
+                        XCTAssertEqual(patchValue, "Read 0 bytes")
+                    }
+                    else {
+                        XCTFail("patchValue's value wasn't an UTF8 string")
+                    }
+                }
+                catch {
+                    XCTFail("Failed reading the body of the response")
+                }
+                expectation.fulfill()
+            })
+        },
+        { expectation in
+            self.performRequest("patch", path: "/patchtest", callback: {response in
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
+                do {
+                    var data = Data()
+                    let count = try response?.readAllData(into: &data)
+                    XCTAssertEqual(count, 13, "Result should have been 13 bytes, was \(String(describing: count)) bytes")
+                    let patchValue = String(data: data as Data, encoding: .utf8)
+                    if  let patchValue = patchValue {
+                        XCTAssertEqual(patchValue, "Read 16 bytes")
                     }
                     else {
                         XCTFail("postValue's value wasn't an UTF8 string")

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -244,7 +244,7 @@ class ClientE2ETests: KituraNetTest {
                         XCTAssertEqual(patchValue, "Read 16 bytes")
                     }
                     else {
-                        XCTFail("postValue's value wasn't an UTF8 string")
+                        XCTFail("patchValue's value wasn't an UTF8 string")
                     }
                 }
                 catch {


### PR DESCRIPTION
## Description
The changes in this PR enable Kitura-net to properly send data with a PATCH request. It also add tests for sending a PATCH request both without and without body data (although a PATCH without body data is not particularly useful).

Kitura-net has specific switch cases for some HTTP method types (GET, POST, PUT etc) when calling libcurl APIs, however, it handles many of the less common request methods (like PATCH) with a catchall default code path. Before this change the code would not tell libcurl that data was forthcoming for a PATCH request, and instead relied on the default libcurl options for a request, plus the one option to change the method name.

This PR adds a new case in the switch to handle PATCH to make sure that the upload option is set.

NOTE: There may be other request types that also need to send data, but researching and implementing the changes for those feels out-of-scope for this PR.

NOTE: Information on the libcurl API is available on the man page, particularly the `CURLOPT_CUSTOMREQUEST` under `curl_easy_setopt()`. (Quick link: https://linux.die.net/man/3/curl_easy_setopt)

## Motivation and Context
PATCH requests are similar to PUT requests except for partial update of a resource.
Therefore it does not make much sense that you cannot send body data with a PATCH request
in Kitura-net. This PR adds a test and fix for this problem. 

## How Has This Been Tested?
I added 2 new tests to the end-to-end tests that are very similar to the PUT tests -- one that makes a PATCH request but sends no data, and one that makes a PATCH request and sends a string of data.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
