### PR TITLE
Fix parsing of responses to HEAD requests with non-zero Content-Length

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -336,7 +336,8 @@ public class ClientRequest {
 
         let invoker = CurlInvoker(handle: handle!, maxRedirects: maxRedirects)
         invoker.delegate = self
-        response = ClientResponse()
+        let skipBody = (method.uppercased() == "HEAD")
+        response = ClientResponse(skipBody: skipBody)
         
         var code = invoker.invoke()
         guard code == CURLE_OK else {

--- a/Sources/KituraNet/ClientResponse.swift
+++ b/Sources/KituraNet/ClientResponse.swift
@@ -47,7 +47,7 @@ public class ClientResponse {
     private static let bufferSize = 2000
     
     /// The http_parser Swift wrapper
-    private var httpParser = HTTPParser(isRequest: false)
+    private var httpParser: HTTPParser
     
     /// State of response parsing
     private var parserStatus = HTTPParserStatus()
@@ -71,7 +71,7 @@ public class ClientResponse {
         if  parserStatus.state == .reset  {
             reset()
         }
-        
+
         let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self) + from
         let (numberParsed, _) = httpParser.execute(bytes, length: length)
         
@@ -155,7 +155,8 @@ public class ClientResponse {
     }
 
     /// Initializes a `ClientResponse` instance
-    init() {
+    init(skipBody: Bool = false) {
+        httpParser = HTTPParser(isRequest: false, skipBody: skipBody)
     }
     
     /// The HTTP Status code, as an Int, sent in the response by the remote server.

--- a/Sources/KituraNet/HTTPParser/HTTPParser.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParser.swift
@@ -63,9 +63,10 @@ class HTTPParser {
     /// Initializes a HTTPParser instance
     ///
     /// - Parameter isRequest: whether or not this HTTP message is a request
+    /// - Parameter skipBody: whether parser should skip body content (ie when parsing the response to a HEAD request)
     ///
     /// - Returns: an HTTPParser instance
-    init(isRequest: Bool) {
+    init(isRequest: Bool, skipBody: Bool = false) {
 
         self.isRequest = isRequest
 
@@ -99,14 +100,35 @@ class HTTPParser {
             return 0
         }
         
-        settings.on_headers_complete = { (parser) -> Int32 in
-            let method = String(cString: get_method(parser))
+        // Callback should return 1 when instructing the C HTTP parser
+        // to skip body content. This closure is bound to a C function
+        // pointer and cannot capture values (including self.skipBody)
+        // so instead we choose which closure to assign outside the
+        // closure.
+        // NOTE: We could extract the common code into a static function
+        //       to reduce duplication.
+        if skipBody {
+            settings.on_headers_complete = { (parser) -> Int32 in
+                let method = String(cString: get_method(parser))
 
-            let results = getResults(parser)
-            
-            results?.onHeadersComplete(method: method, versionMajor: (parser?.pointee.http_major)!,
-                versionMinor: (parser?.pointee.http_minor)!)
-            return 0
+                let results = getResults(parser)
+                
+                results?.onHeadersComplete(method: method, versionMajor: (parser?.pointee.http_major)!,
+                    versionMinor: (parser?.pointee.http_minor)!)
+                
+                return 1
+            }
+        } else {
+            settings.on_headers_complete = { (parser) -> Int32 in
+                let method = String(cString: get_method(parser))
+
+                let results = getResults(parser)
+                
+                results?.onHeadersComplete(method: method, versionMajor: (parser?.pointee.http_major)!,
+                    versionMinor: (parser?.pointee.http_minor)!)
+                
+                return 0
+            }
         }
         
         settings.on_message_complete = { (parser) -> Int32 in
@@ -116,7 +138,7 @@ class HTTPParser {
         
         reset()	
     }
-    
+
     /// Executes the parsing on the byte array
     ///
     /// - Parameter data: pointer to a byte array

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -311,9 +311,7 @@ class ClientE2ETests: KituraNetTest {
                 response.statusCode = .OK
                 XCTAssertEqual(response.statusCode, .OK, "Set response status code wasn't .OK, it was \(String(describing: response.statusCode))")
                 response.headers["Content-Type"] = ["text/plain"]
-                if request.method.lowercased() != "head" {
-                    response.headers["Content-Length"] = ["\(result.characters.count)"]
-                }
+                response.headers["Content-Length"] = ["\(result.characters.count)"]
                 
                 try response.end(text: result)
             }


### PR DESCRIPTION
## Description
I have added a new parameter `skipBody: Bool` to both `ClientReponse.init()` and `HTTPParser.init()` which tells the response to skip parsing of the request body.  These parameters default to `false`.

When the `ClientRequest` creates the `ClientReponse` object to represent the response from the server, it now checks if the `method` is `HEAD` and if so passes `skipBody: true` to the `ClientResponse` constructor. This will be passed down to the `HTTPParser` constructor (this required a small change to the way the `httpParser` property is initialized) where a decision is made on how to initialize the callbacks to the CHTTPParser. If `skipBody` is `false` then the callback is created exactly as before, however, if `skipBody` is `true` then the callback is created so that it returns `1` which tells `CHTTPParser` not to parse the body content.

I was not able to find a better way to communicate this flag to `CHTTPParser` since it clears all the parser `flags` when the parse step begins.

## Motivation and Context
KituraNet client responses to HEAD requests do not properly handle having a non-zero "Content-Length" header. According to the HTTP specification HEAD requests should have identical headers to the corresponding GET request on a given URL -- this includes the "Content-Length" header. It also says that servers MUST NOT provide any body content for responses to HEAD requests.

KituraNet client doesn't handle this scenario properly and the HEAD test server it runs against incorrectly sets the "Content-Length" to 0 when responding to a HEAD request which makes the test pass.

## How Has This Been Tested?
I modified the KituraNet client HEAD tests so the test server sets the "Content-Length" appropriately (which causes the test to fail without the other changes in this PR).

The changes in this PR pass the KituraNet and Kitura tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
