### PR TITLE
Prevent collision on HTTPParser state by consecutive keepalive requests

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -120,7 +120,6 @@ public class HTTPServerResponse : ServerResponse {
             // Ordering is important here. Keepalive allows the processor to continue
             // processing further requests, so must only be called once monitoring
             // has completed, as the HTTPParser for this connection is reused.
-            processor.handlingComplete()
             if  keepAlive {
                 processor.keepAlive()
             }

--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -107,22 +107,22 @@ public class HTTPServerResponse : ServerResponse {
     public func end() throws {
         if let processor = processor {
             try flushStart()
-            
-            let keepAlive = processor.isKeepAlive
-            
-            if  keepAlive {
-                processor.keepAlive()
-            }
-            
             if  buffer.length > 0  {
                 processor.write(from: buffer)
             }
-            
+            let keepAlive = processor.isKeepAlive
             if !keepAlive && !processor.isUpgrade {
                 processor.close()
             }
             if let request = request {
                 Monitor.delegate?.finished(request: request, response: self)
+            }
+            // Ordering is important here. Keepalive allows the processor to continue
+            // processing further requests, so must only be called once monitoring
+            // has completed, as the HTTPParser for this connection is reused.
+            processor.handlingComplete()
+            if  keepAlive {
+                processor.keepAlive()
             }
         }
     }

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -123,7 +123,6 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         keepAliveUntil=0.0
         inProgress = false
         clientRequestedKeepAlive = false
-        parserUnlock()  // In case the socket was closed while we were handling a request
         handler?.prepareToClose()
     }
     
@@ -187,16 +186,15 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     /// Invoke the HTTP parser against the specified buffer of data and
     /// convert the HTTP parser's status to our own.
     private func parse(_ buffer: NSData) {
-        parserLock()
         let parsingStatus = parse(buffer, from: parseStartingFrom)
-        parserUnlock()
-
+        
         if parsingStatus.bytesLeft == 0 {
             parseStartingFrom = 0
         }
         else {
             parseStartingFrom = buffer.length - parsingStatus.bytesLeft
         }
+        
         guard  parsingStatus.error == nil  else  {
             Log.error("Failed to parse a request. \(parsingStatus.error!)")
             let response = HTTPServerResponse(processor: self, request: nil)
@@ -205,6 +203,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
                 try response.end()
             }
             catch {}
+
             return
         }
         
@@ -241,12 +240,6 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
             inProgress = false
         }
         else {
-            // Prevent changes to the HTTPParser's state during handling of the request.
-            // Once handling has finished, the HTTPServerResponse will call handlingComplete()
-            // to unlock the parser. It cannot be called within the closure below, because
-            // handle will first try to process buffered data, and the lock must be released
-            // before this can happen.
-            parserLock()
             weak var weakRequest = request
             DispatchQueue.global().async() { [weak self] in
                 if let strongSelf = self, let strongRequest = weakRequest {
@@ -257,13 +250,6 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         }
     }
     
-    /// Called by the request handler to signify that it has finished making use of the
-    /// HTTPServerRequest (and the HTTPParser it refers to), such that the parser can
-    /// safely be reused.
-    func handlingComplete() {
-        parserUnlock()
-    }
-    
     /// A socket can be kept alive for future requests. Set it up for future requests and mark how long it can be idle.
     func keepAlive() {
         state = .reset
@@ -272,21 +258,6 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         keepAliveUntil = Date(timeIntervalSinceNow: IncomingHTTPSocketProcessor.keepAliveTimeout).timeIntervalSinceReferenceDate
         handler?.handleBufferedReadData()
     }
-    
-    private let parserSemaphore = DispatchSemaphore(value: 1)
-    
-    /// Indicate that we are dependent on the state of the HTTPParser.
-    /// This should be obtained before executing the parser.
-    /// If we are ready to handle a request, we will retain this lock until handling is complete.
-    private func parserLock() {
-        parserSemaphore.wait()
-    }
-    
-    /// Indicate that we are no longer dependent on the state of the HTTPParser.
-    private func parserUnlock() {
-        parserSemaphore.signal()
-    }
-
 }
 
 class HTTPIncomingSocketProcessorCreator: IncomingSocketProcessorCreator {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
~~Adds a lock around the use of the `HTTPParser`'s state~~ 
Move the `keepAlive()` call in `HTTPServerRequest` to be the last action taken during `end()`, to prevent data associated with an `HTTPServerRequest` (such as the `method`) from being overwritten by a subsequent request on the same Keep-Alive connection before `end()` completes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #226 

This fixes a timing window which is exposed by the SwiftMetricsKitura HTTP monitoring.

As soon as the response has been sent, the `IncomingHTTPSocketProcessor`'s state - and the `HTTPParser` associated with it - are reset, ready to handle a subsequent request from the same client.

The monitoring `finished()` events are processed synchronously on a serial queue, after a response has been sent to the client. However, because the entire handling of a request is performed on a separate thread to the socket reader, the reader is free to start processing a new request as soon as `keepAlive()` is called.

There is then a race between the client receiving the response and immediately sending the next request, and the monitoring processing the event that was queued (which will read values such as the `method` from the `HTTPServerRequest`).  Occasionally, the server will crash because the `ParseResults` is being mutated for the new request whilst it is still associated with the previous one (two `HTTPServerRequest` instances exist with a reference to the same `HTTPParser`).

Another change we could consider would be to copy the values needed for monitoring, then perform the monitoring asynchronously. This would add some small overhead, but would allow a subsequent request to be processed without waiting for monitoring to complete.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have run the Kitura-net tests on Linux and Mac.

I've also verified that this resolves the intermittent crash with SwiftMetricsKitura on Linux and Mac.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
