### PR TITLE
Support HTTP Pipelining

### DIFF
--- a/Sources/KituraNet/HTTPParser/HTTPParser.swift
+++ b/Sources/KituraNet/HTTPParser/HTTPParser.swift
@@ -117,8 +117,16 @@ class HTTPParser {
             }
         }
         
+        // When the parser reaches the end of a message, we will pause
+        // so that execute() completes and the handler can be invoked.
+        // Any remaining data in the buffer will be consumed as follows:
+        // - if Keep-Alive is disabled, the data will be discarded.
+        // - if Keep-Alive is enabled, the keepAlive() call and the
+        //   subsequent handleBuffererdReadData() call will reset the
+        //   parser's state, and then resume parsing the buffer.
         settings.on_message_complete = { (parser) -> Int32 in
             getResults(parser)?.onMessageComplete()
+            http_parser_pause(parser, 1)
             return 0
         }
         

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -15,6 +15,7 @@
  **/
 
 import Foundation
+import Dispatch
 
 import XCTest
 
@@ -190,7 +191,6 @@ class ClientE2ETests: KituraNetTest {
                 if responseBody != expectedResponse {
                     XCTFail("Expected: '\(expectedResponse)', but response \(responseNumber) was: '\(responseBody)'")
                 }
-                print("ok \(responseNumber)")
             }
             // We completed reading the responses, cancel the recovery task
             recoveryTask.cancel()

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -32,6 +32,8 @@ class ClientE2ETests: KituraNetTest {
             ("testPostRequests", testPostRequests),
             ("testPutRequests", testPutRequests),
             ("testPatchRequests", testPatchRequests),
+            ("testPipelining", testPipelining),
+            ("testPipeliningSpanningPackets", testPipeliningSpanningPackets),
             ("testSimpleHTTPClient", testSimpleHTTPClient),
             ("testUrlURL", testUrlURL)
         ]
@@ -90,7 +92,115 @@ class ClientE2ETests: KituraNetTest {
             })
         })
     }
-
+    
+    /// Tests that the server responds appropriately to pipelined requests.
+    /// Three POST requests are sent to a test server in a single socket write. The
+    /// server is expected to process them sequentially, sending three separate
+    /// responses, each indicating that a body of 6 bytes was received.
+    func testPipelining() {
+        let postRequest = "POST / HTTP/1.1\r\nHost: localhost:8080\r\nContent-Length: 6\r\n\r\nabcdef"
+        let expectedResponse = "Read 6 bytes"
+        let totalRequests = 3
+        let pipelinedRequests = String(repeating: postRequest, count: totalRequests)
+        doPipelineTest(expecting: expectedResponse, totalRequests: totalRequests) {
+            socket in
+            try socket.write(from: pipelinedRequests)
+        }
+    }
+        
+    /// Tests that the server responds appropriately to pipelined requests.
+    /// Three POST requests are sent to a test server in a pipelined fashion, but
+    /// spanning several packets. It is necessary to sleep between writes to allow
+    /// the server time to receive and process the data.
+    func testPipeliningSpanningPackets() {
+        let firstBuffer = "POST / HTTP/1.1\r\nHost: localhost:8080\r\nContent-Length: 6\r\n\r\nabcdefPOST / HTTP/1.1\r\nHost: localhost:80"
+        let secondBuffer = "80\r\nContent-Length: 6\r\n\r\nabcdefPO"
+        let thirdBuffer = "ST / HTTP/1.1\r\nHost: localhost:8080\r\nContent-Length: 6\r\n\r\nabcdef"
+        let expectedResponse = "Read 6 bytes"
+        let totalRequests = 2
+        doPipelineTest(expecting: expectedResponse, totalRequests: totalRequests) {
+            socket in
+            // Disable Nagle's algorithm on this socket to flush first write
+            var on: Int32 = 1
+            setsockopt(socket.socketfd, Int32(IPPROTO_TCP), TCP_NODELAY, &on, socklen_t(MemoryLayout<Int32>.size))
+            try socket.write(from: firstBuffer)
+            usleep(1000)
+            try socket.write(from: secondBuffer)
+            usleep(1000)
+            try socket.write(from: thirdBuffer)
+        }
+    }
+    
+    private func doPipelineTest(expecting expectedResponse: String, totalRequests: Int, writer: (Socket) throws -> Void) {
+        do {
+            let server: HTTPServer = try startServer(TestServerDelegate(), port: 0, useSSL: false)
+            defer {
+                server.stop()
+            }
+            
+            guard let serverPort = server.port else {
+                XCTFail("Server port was not initialized")
+                return
+            }
+            XCTAssertTrue(serverPort != 0, "Ephemeral server port not set")
+            
+            // Send pipelined requests to the server
+            let clientSocket = try Socket.create()
+            try clientSocket.connect(to: "localhost", port: Int32(serverPort))
+            defer {
+                clientSocket.close()
+            }
+            try writer(clientSocket)
+            //try clientSocket.write(from: pipelinedRequests)
+            
+            // Queue a recovery task to close our socket so that the test cannot wait forever
+            // waiting for responses from the server
+            let recoveryTask = DispatchWorkItem {
+                XCTFail("Timed out waiting for responses from server")
+                clientSocket.close()
+            }
+            let timeout = DispatchTime.now() + .seconds(1)
+            DispatchQueue.global().asyncAfter(deadline: timeout, execute: recoveryTask)
+            
+            // Read responses from the server
+            let buffer = NSMutableData(capacity: 2000)!
+            var read = 0
+            var bufferPosition = 0
+            var responsesToRead = totalRequests
+            while responsesToRead > 0 {
+                responsesToRead -= 1
+                let response = ClientResponse()
+                while true {
+                    XCTAssert(read == buffer.length, "Bytes read does not equal buffer length")
+                    let status = response.parse(buffer, from: bufferPosition)
+                    bufferPosition = buffer.length - status.bytesLeft
+                    if status.state == .messageComplete {
+                        break
+                    }
+                    read += try clientSocket.read(into: buffer)
+                }
+                let responseNumber = totalRequests - responsesToRead
+                // Check that the response indicates success
+                XCTAssert(response.httpStatusCode == .OK, "Response \(responseNumber) was not 200/OK, was \(response.httpStatusCode)")
+                guard let responseBody = try response.readString() else {
+                    XCTFail("Unable to read body of response \(responseNumber)")
+                    break
+                }
+                // Check that the response body contains the expected content
+                if responseBody != expectedResponse {
+                    XCTFail("Expected: '\(expectedResponse)', but response \(responseNumber) was: '\(responseBody)'")
+                }
+                print("ok \(responseNumber)")
+            }
+            // We completed reading the responses, cancel the recovery task
+            recoveryTask.cancel()
+            XCTAssert(bufferPosition == buffer.length, "Unparsed bytes remaining after final response")
+            
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
     func testEphemeralListeningPort() {
         do {
             let server = try HTTPServer.listen(on: 0, delegate: delegate)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows Kitura-net to handle pipelined requests, by pausing the `http_parser` when the `on_message_complete` callback is triggered.  This causes the `http_parser_execute` function to return, rather than continuing to process the rest of the buffer, and allows the processor to handle the first request.

Upon the completion of the response, `keepAlive()` is called, followed by `processBufferedReadData()`, which resets the parser state, and resumes parsing the buffer.

**Note** - On Linux, with the default (epoll) I/O implementation, pipelining is now functional but performs very slowly.  It works (and performs) correctly with GCD both on Linux and Mac.  I've raised a separate PR #230 to resolve it.  Performance is unaffected when pipelining is not used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves IBM-Swift/Kitura#932

HTTP Pipelining support is required by the [TechEmpower Benchmarks](https://www.techempower.com/benchmarks/), which uses it during the `plaintext` test.  This is therefore a prerequisite to a correctly functioning Kitura TechEmpower implementation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the Kitura-net tests on Mac and Linux locally, and they passed.
I used `wrk` to test pipelining, as follows:
```
wrk -c128 -t16 -d10s -i1s http://localhost:8080/plaintext --script pipeline.lua 16 --
```
The `pipeline.lua` script for `wrk` is [generated by the TechEmpower benchmarks project](https://github.com/TechEmpower/FrameworkBenchmarks/blob/70a2dac6639cf731dc7c5730333d2ce4116c39b5/toolset/setup/linux/client.sh#L33) - a copy is available here: https://github.com/djones6/Swift-Bench/blob/master/pipeline.lua

I have added a couple of E2E tests for pipelining.  Since `ClientRequest` does not support the notion of pipelining, I have done this using Socket directly with hand-crafted requests.  We are still able to use the `ClientResponse` to inspect the results.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
