### PR TITLE
Improve performance of HTTP Pipelining on Linux

### DIFF
--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -211,8 +211,10 @@ public class IncomingSocketHandler {
             }
         #endif
         #if !GCD_ASYNCH && os(Linux)
-            // Wake the epoll_wait thread early to allow it to process the buffer
-            eventfd_write(epollWakeFd, 0)
+            if readBuffer.length > 0 {
+                // Wake the epoll_wait thread early to allow it to process the buffer
+                eventfd_write(epollWakeFd, 0)
+            }
         #endif
     }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds an `eventfd` to the epoll descriptor which can be used to wake the `epoll_wait()` when it is time to process any buffered data (such as an additional pipelined request).  The `eventfd_write()` function is used to trigger an event on this fd.

**Note:** this requires IBM-Swift/CEpoll#2

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#229 allowed HTTP Pipelining to function properly, but on Linux, due to the design of our `epoll_wait()` loop, each pipelined request is delayed by around 50ms (epoll_wait timeout) before it is processed.  Further detail in IBM-Swift/Kitura#932.

By waking the `epoll_wait()` after the `keepAlive()` call, we can immediately process the buffered data.

We must wake the epoll thread rather than calling the `handleBufferedReadDataHelper()` directly, because we otherwise run the risk of accessing the `IncomingHTTPSocketProcessor` concurrently in two different threads (the handler thread which just called `keepAlive()`, and the epoll thread, which may wake up if the client sends more data).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the Kitura-net tests, and they passed.
I ran the performance test described in #229 and verified the performance issue on Linux is resolved.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
