### PR TITLE
Close Keep-Alive connections following a parser error

### DIFF
--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -199,6 +199,9 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
             Log.error("Failed to parse a request. \(parsingStatus.error!)")
             let response = HTTPServerResponse(processor: self, request: nil)
             response.statusCode = .badRequest
+            // We must avoid any further attempts to process data from this client
+            // after a parser error has occurred. (see Kitura-net#228)
+            clientRequestedKeepAlive = false
             do {
                 try response.end()
             }

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -49,11 +49,14 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
     ///HTTP Parser
     private let httpParser: HTTPParser
     
+    /// Indicates whether the HTTP parser has encountered a parsing error
+    private var parserErrored = false
+    
     /// Controls the number of requests that may be sent on this connection.
     private(set) var keepAliveState: KeepAliveState
     
     /// Should this socket actually be kept alive?
-    var isKeepAlive: Bool { return clientRequestedKeepAlive && keepAliveState.keepAlive() }
+    var isKeepAlive: Bool { return clientRequestedKeepAlive && keepAliveState.keepAlive() && !parserErrored }
     
     let socket: Socket
     
@@ -201,7 +204,7 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
             response.statusCode = .badRequest
             // We must avoid any further attempts to process data from this client
             // after a parser error has occurred. (see Kitura-net#228)
-            clientRequestedKeepAlive = false
+            parserErrored = true
             do {
                 try response.end()
             }

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -192,8 +192,10 @@ public class IncomingSocketHandler {
     public func handleBufferedReadData() {
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
             if socket.socketfd != Socket.SOCKET_INVALID_DESCRIPTOR {
-                socketReaderQueue.sync() { [unowned self] in
-                    _ = self.handleBufferedReadDataHelper()
+                socketReaderQueue.sync() { [weak self] in
+                    if let strongSelf = self {
+                        _ = strongSelf.handleBufferedReadDataHelper()
+                    }
                 }
             }
         #endif

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -134,16 +134,12 @@ class ClientE2ETests: KituraNetTest {
     
     private func doPipelineTest(expecting expectedResponse: String, totalRequests: Int, writer: (Socket) throws -> Void) {
         do {
-            let server: HTTPServer = try startServer(TestServerDelegate(), port: 0, useSSL: false)
+            let server: HTTPServer
+            let serverPort: Int
+            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: false)
             defer {
                 server.stop()
             }
-            
-            guard let serverPort = server.port else {
-                XCTFail("Server port was not initialized")
-                return
-            }
-            XCTAssertTrue(serverPort != 0, "Ephemeral server port not set")
             
             // Send pipelined requests to the server
             let clientSocket = try Socket.create()

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -22,6 +22,10 @@ import Foundation
 import Dispatch
 import SSLService
 
+struct KituraNetTestError: Swift.Error {
+    let message: String
+}
+
 class KituraNetTest: XCTestCase {
 
     static let useSSLDefault = true
@@ -67,6 +71,19 @@ class KituraNetTest: XCTestCase {
         }
         try server.listen(on: port)
         return server
+    }
+    
+    /// Convenience function for starting an HTTPServer on an ephemeral port,
+    /// returning the a tuple containing the server and the port it is listening on.
+    func startEphemeralServer(_ delegate: ServerDelegate?, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault) throws -> (server: HTTPServer, port: Int) {
+        let server = try startServer(delegate, port: 0, useSSL: useSSL, allowPortReuse: allowPortReuse)
+        guard let serverPort = server.port else {
+            throw KituraNetTestError(message: "Server port was not initialized")
+        }
+        guard serverPort != 0 else {
+            throw KituraNetTestError(message: "Ephemeral server port not set (was zero)")
+        }
+        return (server, serverPort)
     }
     
     func performServerTest(_ delegate: ServerDelegate?, port: Int = portDefault, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault,

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -198,5 +198,163 @@ class RegressionTests: KituraNetTest {
             XCTFail("Error: \(error)")
         }
     }
+    
+    /// Tests that sending a bad request results in a `400/Bad Request` response
+    /// from the server with `Connection: Close` header.
+    func testBadRequest() {
+        let requestBuffer = "GET / HTTP/1.1\r\nFOO\r\n\r\n"
+        do {
+            let server: HTTPServer
+            let serverPort: Int
+            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: false)
+            defer {
+                server.stop()
+            }
+            
+            // Send request to the server
+            let clientSocket = try Socket.create()
+            try clientSocket.connect(to: "localhost", port: Int32(serverPort))
+            defer {
+                clientSocket.close()
+            }
+            try clientSocket.write(from: requestBuffer)
+            
+            // Queue a recovery task to close our socket so that the test cannot wait forever
+            // waiting for responses from the server
+            let recoveryTask = DispatchWorkItem {
+                XCTFail("Timed out waiting for responses from server")
+                clientSocket.close()
+            }
+            let timeout = DispatchTime.now() + .seconds(1)
+            DispatchQueue.global().asyncAfter(deadline: timeout, execute: recoveryTask)
+            
+            // Read responses from the server
+            let buffer = NSMutableData(capacity: 2000)!
+            var read = 0
+            var bufferPosition = 0
+            let response = ClientResponse()
+            while true {
+                XCTAssert(read == buffer.length, "Bytes read does not equal buffer length")
+                let status = response.parse(buffer, from: bufferPosition)
+                bufferPosition = buffer.length - status.bytesLeft
+                if status.state == .messageComplete {
+                    break
+                }
+                read += try clientSocket.read(into: buffer)
+            }
+            // Check that the response indicates failure
+            validate400Response(response: response, responseNumber: 1)
+            // We completed reading the responses, cancel the recovery task
+            recoveryTask.cancel()
+            XCTAssert(bufferPosition == buffer.length, "Unparsed bytes remaining after final response")
+            
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+
+    /// Tests that sending a good request followed by garbage on a Keep-Alive
+    /// connection results in a `200/OK` response, followed by a `400/Bad Request`
+    /// response with `Connection: Close` header.
+    /// This is to verify the fix introduced in Kitura-net PR #229, where a malformed
+    /// request sent during a Keep-Alive session could cause the server to crash.
+    func testBadRequestFollowingGoodRequest() {
+        let requestBuffer = "GET / HTTP/1.1\r\n\r\nFOO\r\n"
+        let totalRequests = 2
+        do {
+            let server: HTTPServer
+            let serverPort: Int
+            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: false)
+            defer {
+                server.stop()
+            }
+            
+            // Send requests to the server
+            let clientSocket = try Socket.create()
+            try clientSocket.connect(to: "localhost", port: Int32(serverPort))
+            defer {
+                clientSocket.close()
+            }
+            try clientSocket.write(from: requestBuffer)
+            
+            // Queue a recovery task to close our socket so that the test cannot wait forever
+            // waiting for responses from the server
+            let recoveryTask = DispatchWorkItem {
+                XCTFail("Timed out waiting for responses from server")
+                clientSocket.close()
+            }
+            let timeout = DispatchTime.now() + .seconds(1)
+            DispatchQueue.global().asyncAfter(deadline: timeout, execute: recoveryTask)
+            
+            // Read responses from the server
+            let buffer = NSMutableData(capacity: 2000)!
+            var read = 0
+            var bufferPosition = 0
+            var responsesToRead = totalRequests
+            while responsesToRead > 0 {
+                responsesToRead -= 1
+                let response = ClientResponse()
+                while true {
+                    XCTAssert(read == buffer.length, "Bytes read does not equal buffer length")
+                    let status = response.parse(buffer, from: bufferPosition)
+                    bufferPosition = buffer.length - status.bytesLeft
+                    if status.state == .messageComplete {
+                        break
+                    }
+                    read += try clientSocket.read(into: buffer)
+                }
+                let responseNumber = totalRequests - responsesToRead
+                switch responseNumber {
+                case 1:
+                    validate200Response(response: response, responseNumber: responseNumber)
+                case 2:
+                    validate400Response(response: response, responseNumber: responseNumber)
+                default:
+                    XCTFail("Unexpected responseNumber \(responseNumber)")
+                }
+                // Check that the response indicates success
+                
+            }
+            // We completed reading the responses, cancel the recovery task
+            recoveryTask.cancel()
+            XCTAssert(bufferPosition == buffer.length, "Unparsed bytes remaining after final response")
+            
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    /// Checks that the provided ClientResponse represents an HTTP `200 OK`
+    /// response from the server with an appropriate `Connection: Keep-Alive`
+    /// header.
+    private func validate200Response(response: ClientResponse, responseNumber: Int) {
+        XCTAssert(response.httpStatusCode == .OK, "Response \(responseNumber) was not 200/OK, was \(response.httpStatusCode)")
+        guard let connectionHeader = response.headers["Connection"] else {
+            XCTFail("Response did not contain a 'Connection' header")
+            return
+        }
+        guard connectionHeader.count == 1 else {
+            XCTFail("Connection header did not have a single value: \(connectionHeader)")
+            return
+        }
+        let connectionValue = connectionHeader[0]
+        XCTAssert(connectionValue == "Keep-Alive", "Response 'Connection' header should be 'Keep-Alive', but was \(connectionValue)")
+    }
+    
+    /// Checks that the provided ClientResponse represents an HTTP `400 Bad Request`
+    /// response from the server with an appropriate `Connection: Close` header.
+    private func validate400Response(response: ClientResponse, responseNumber: Int) {
+        XCTAssert(response.httpStatusCode == .badRequest, "Response was not 400/Bad Request, was \(response.httpStatusCode)")
+        guard let connectionHeader = response.headers["Connection"] else {
+            XCTFail("Response did not contain a 'Connection' header")
+            return
+        }
+        guard connectionHeader.count == 1 else {
+            XCTFail("Connection header did not have a single value: \(connectionHeader)")
+            return
+        }
+        let connectionValue = connectionHeader[0]
+        XCTAssert(connectionValue == "Close", "Response 'Connection' header should be 'Close', but was \(connectionValue)")
+    }
 
 }

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -28,6 +28,10 @@ class RegressionTests: KituraNetTest {
     static var allTests : [(String, (RegressionTests) -> () throws -> Void)] {
         return [
             ("testIssue1143", testIssue1143),
+            ("testServersCollidingOnPort", testServersCollidingOnPort),
+            ("testServersSharingPort", testServersSharingPort),
+            ("testBadRequest", testBadRequest),
+            ("testBadRequestFollowingGoodRequest", testBadRequestFollowingGoodRequest),
         ]
     }
     

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -59,17 +59,13 @@ class RegressionTests: KituraNetTest {
     /// connections.
     func testIssue1143() {
         do {
-            let server: HTTPServer = try startServer(nil, port: 0, useSSL: true)
+            let server: HTTPServer
+            let serverPort: Int
+            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: true)
             defer {
                 server.stop()
             }
 
-            guard let serverPort = server.port else {
-                XCTFail("Server port was not initialized")
-                return
-            }
-            XCTAssertTrue(serverPort != 0, "Ephemeral server port not set")
-            
             // Queue a server stop operation in 1 second, in case the test hangs (socket listener blocks)
             let recoveryOperation = DispatchWorkItem {
                 server.stop()
@@ -152,16 +148,12 @@ class RegressionTests: KituraNetTest {
     /// Tests that attempting to start a second HTTPServer on the same port fails.
     func testServersCollidingOnPort() {
         do {
-            let server: HTTPServer = try startServer(nil, port: 0, useSSL: false)
+            let server: HTTPServer
+            let serverPort: Int
+            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: false)
             defer {
                 server.stop()
             }
-            
-            guard let serverPort = server.port else {
-                XCTFail("Server port was not initialized")
-                return
-            }
-            XCTAssertTrue(serverPort != 0, "Ephemeral server port not set")
             
             do {
                 let collidingServer: HTTPServer = try startServer(nil, port: serverPort, useSSL: false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolves a bug in Keep-Alive handling, which results in an infinite loop (with epoll) or a crash (with GCD) when a malformed request is sent on a Keep-Alive connection, after a previous message has been successfully processed.

## Motivation and Context
May address #228 

Recreate is as simple as:
```
curl -X GET -H 'Content-Length: 0' -H 'Connection: Keep-Alive' -d"abcd" http://localhost:8080/
```
This problem does not occur if `Connection: Close` is sent. In this situation, after handling the initial request, whether successful or not, we close the connection.

The problem also does not occur if the first message from the client is invalid (regardless of the `Connection` header). In this case, we immediately respond with `400 Bad Request` and close the connection.  This only happens due to ordering of when the `clientRequestedKeepAlive` flag is updated: we only set this flag to `true` once a request has been successfully parsed.

### Symptom
In the case of epoll, we repeatedly attempt to parse the remaining buffer as the epoll_wait times out every 50ms, and we have a handler in the list of handlers that require deferred processing.

In the case of GCD, we attempt to invoke `self.handleBufferedReadDataHelper()` as part of a direct call to `end()` when a parser error has occurred.  In this situation, we attempt to synchronously enqueue a block to the queue we are already executing on, which results in a crash.

### Solution
The solution presented here is to introduce a new piece of state: `parserErrored`, which is checked when evaluating `isKeepAlive`, in addition to `clientRequestedKeepAlive`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the Kitura-net tests locally on Linux and Mac.  I tested with the `curl` example above to verify that the problem is fixed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
