### PR TITLE
Allow POST success status codes besides 201 (CREATED)

### DIFF
--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -118,3 +118,15 @@ public enum HTTPStatusCode: Int {
     case unsupportedMediaType = 415, useProxy = 305, misdirectedRequest = 421, unknown = -1
     
 }
+
+extension HTTPStatusCode: Comparable {
+
+    public static func <(lhs: HTTPStatusCode, rhs: HTTPStatusCode) -> Bool { return lhs.rawValue < rhs.rawValue }
+
+}
+
+extension HTTPStatusCode {
+
+    public static var successRange: Range<HTTPStatusCode> { return .OK ..< .multipleChoices }
+
+}


### PR DESCRIPTION
Allow POST success status codes besides 201 (CREATED)

## Description
This change adds HTTPStatusCode extensions for identifying whether a status code represents success. The remainder of the change is PRed to Kitura: https://github.com/IBM-Swift/Kitura/pull/1218

## Motivation and Context
When Kitura receives a POST, its success response is 201 (CREATED). If one explicitly specifies any other success response, such as 200 (OK), Kitura treats it like an error.

## How Has This Been Tested?
Ran `swift test`.
Have been using this modification at Capital One for several months.

## Checklist:
- [x ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.