### PR TITLE
Define additional ranges on HTTPStatusCode

### DIFF
--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -127,6 +127,19 @@ extension HTTPStatusCode: Comparable {
 
 extension HTTPStatusCode {
 
+    /// The range of HTTP status codes that represent informational responses (1xx)
+    public static var informationalRange: Range<HTTPStatusCode> { return .`continue` ..< .OK }
+
+    /// The range of HTTP status codes that represent success (2xx)
     public static var successRange: Range<HTTPStatusCode> { return .OK ..< .multipleChoices }
+
+    /// The range of HTTP status codes that represent redirection (3xx)
+    public static var redirectionRange: Range<HTTPStatusCode> { return .multipleChoices ..< .badRequest }
+
+    /// The range of HTTP status codes that represent client errors (4xx)
+    public static var clientErrorRange: Range<HTTPStatusCode> { return .badRequest ..< .internalServerError }
+
+    /// The range of HTTP status codes that represent server errors (5xx)
+    public static var serverErrorRange: ClosedRange<HTTPStatusCode> { return .internalServerError ... .networkAuthenticationRequired }
 
 }

--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
+/* 
+ * This source file includes content derived from the Swift.org Server APIs open source project
+ * (http://github.com/swift-server/http)
+ *
+ * Copyright (c) 2017 Swift Server API project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See http://swift.org/LICENSE.txt for license information
+ */
+
 import Foundation
 
 // MARK: HTTP
@@ -119,27 +129,39 @@ public enum HTTPStatusCode: Int {
     
 }
 
-extension HTTPStatusCode: Comparable {
-
-    public static func <(lhs: HTTPStatusCode, rhs: HTTPStatusCode) -> Bool { return lhs.rawValue < rhs.rawValue }
-
-}
-
 extension HTTPStatusCode {
 
-    /// The range of HTTP status codes that represent informational responses (1xx)
-    public static var informationalRange: Range<HTTPStatusCode> { return .`continue` ..< .OK }
+    /// The class of a `HTTPStatusCode` code
+    /// - See: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml for more information
+    public enum Class {
+        /// Informational: the request was received, and is continuing to be processed
+        case informational
+        /// Success: the action was successfully received, understood, and accepted
+        case successful
+        /// Redirection: further action must be taken in order to complete the request
+        case redirection
+        /// Client Error: the request contains bad syntax or cannot be fulfilled
+        case clientError
+        /// Server Error: the server failed to fulfill an apparently valid request
+        case serverError
+        /// Invalid: the code does not map to a well known status code class
+        case invalidStatus
 
-    /// The range of HTTP status codes that represent success (2xx)
-    public static var successRange: Range<HTTPStatusCode> { return .OK ..< .multipleChoices }
+        init(code: Int) {
+            switch code {
+                case 100..<200: self = .informational
+                case 200..<300: self = .successful
+                case 300..<400: self = .redirection
+                case 400..<500: self = .clientError
+                case 500..<600: self = .serverError
+                default: self = .invalidStatus
+            }
+        }
+    }
 
-    /// The range of HTTP status codes that represent redirection (3xx)
-    public static var redirectionRange: Range<HTTPStatusCode> { return .multipleChoices ..< .badRequest }
-
-    /// The range of HTTP status codes that represent client errors (4xx)
-    public static var clientErrorRange: Range<HTTPStatusCode> { return .badRequest ..< .internalServerError }
-
-    /// The range of HTTP status codes that represent server errors (5xx)
-    public static var serverErrorRange: ClosedRange<HTTPStatusCode> { return .internalServerError ... .networkAuthenticationRequired }
+    /// The `Class` representing the class of status code for this response status
+    public var `class`: Class {
+        return Class(code: self.rawValue)
+    }
 
 }

--- a/Tests/KituraNetTests/HTTPStatusCodeTests.swift
+++ b/Tests/KituraNetTests/HTTPStatusCodeTests.swift
@@ -43,6 +43,25 @@ class HTTPStatusCodeTests: KituraNetTest {
     XCTAssertTrue(HTTPStatusCode.multipleChoices.class == .redirection)
     XCTAssertTrue(HTTPStatusCode.badRequest.class == .clientError)
     XCTAssertTrue(HTTPStatusCode.internalServerError.class == .serverError)
+    XCTAssertTrue(HTTPStatusCode.unknown.class == .invalidStatus)
+  }
+
+  // Test that every code that can be instantiated maps to its expected status class.
+  func testClassOfEveryValidCode() {
+
+    func verifyClass(range: CountableRange<Int>, expectedClass: HTTPStatusCode.Class) {
+      for code in range {
+        let statusCode = HTTPStatusCode(rawValue: code)
+        if let statusCode = statusCode {
+          XCTAssertTrue(statusCode.class == expectedClass, "\(statusCode) should be within \(expectedClass)")
+        }
+      }
+    }
+    verifyClass(range: 100 ..< 200, expectedClass: .informational)
+    verifyClass(range: 200 ..< 300, expectedClass: .successful)
+    verifyClass(range: 300 ..< 400, expectedClass: .redirection)
+    verifyClass(range: 400 ..< 500, expectedClass: .clientError)
+    verifyClass(range: 500 ..< 600, expectedClass: .serverError)
   }
 
 }
@@ -53,6 +72,7 @@ extension HTTPStatusCodeTests {
              ("testStatusCodeCreation", testStatusCodeCreation),
              ("testInvalidStatusCode", testInvalidStatusCode),
              ("testClassOfStatusCode", testClassOfStatusCode),
+             ("testClassOfEveryValidCode", testClassOfEveryValidCode),
     ]
   }
 }

--- a/Tests/KituraNetTests/HTTPStatusCodeTests.swift
+++ b/Tests/KituraNetTests/HTTPStatusCodeTests.swift
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import XCTest
+
+@testable import KituraNet
+
+class HTTPStatusCodeTests: KituraNetTest {
+  
+  func testSuccessRange() {
+    let rawOK = HTTPStatusCode(rawValue: 200)
+    XCTAssertNotNil(rawOK)
+    if let rawOK = rawOK {
+        XCTAssertTrue(HTTPStatusCode.successRange.contains(rawOK))
+    }
+    XCTAssertTrue(HTTPStatusCode.successRange.contains(.OK))
+
+    let rawContinue = HTTPStatusCode(rawValue: 100)
+    XCTAssertNotNil(rawContinue)
+    if let rawContinue = rawContinue {
+        XCTAssertFalse(HTTPStatusCode.successRange.contains(rawContinue))
+    }
+    XCTAssertFalse(HTTPStatusCode.successRange.contains(.`continue`))
+
+    let rawMultipleChoices = HTTPStatusCode(rawValue: 300)
+    XCTAssertNotNil(rawMultipleChoices)
+    if let rawMultipleChoices = rawMultipleChoices {
+        XCTAssertFalse(HTTPStatusCode.successRange.contains(rawMultipleChoices))
+    }
+    XCTAssertFalse(HTTPStatusCode.successRange.contains(.multipleChoices))
+  }
+
+  func testServerErrorRange() {
+    let rawInternalError = HTTPStatusCode(rawValue: 500)
+    XCTAssertNotNil(rawInternalError)
+    if let rawInternalError = rawInternalError {
+        XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(rawInternalError))
+    }
+    XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(.internalServerError))
+
+    let rawNetAuthReqd = HTTPStatusCode(rawValue: 511)
+    XCTAssertNotNil(rawNetAuthReqd)
+    if let rawNetAuthReqd = rawNetAuthReqd {
+        XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(rawNetAuthReqd))
+    }
+    XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(.networkAuthenticationRequired))
+
+    let rawBadRequest = HTTPStatusCode(rawValue: 400)
+    XCTAssertNotNil(rawBadRequest)
+    if let rawBadRequest = rawBadRequest {
+        XCTAssertFalse(HTTPStatusCode.serverErrorRange.contains(rawBadRequest))
+    }
+    XCTAssertFalse(HTTPStatusCode.serverErrorRange.contains(.badRequest))
+  }
+
+}
+
+extension HTTPStatusCodeTests {
+  static var allTests : [(String, (HTTPStatusCodeTests) -> () throws -> Void)] {
+    return [
+             ("testSuccessRange", testSuccessRange),
+             ("testServerErrorRange", testServerErrorRange),
+    ]
+  }
+}

--- a/Tests/KituraNetTests/HTTPStatusCodeTests.swift
+++ b/Tests/KituraNetTests/HTTPStatusCodeTests.swift
@@ -20,51 +20,29 @@ import XCTest
 @testable import KituraNet
 
 class HTTPStatusCodeTests: KituraNetTest {
-  
-  func testSuccessRange() {
-    let rawOK = HTTPStatusCode(rawValue: 200)
-    XCTAssertNotNil(rawOK)
-    if let rawOK = rawOK {
-        XCTAssertTrue(HTTPStatusCode.successRange.contains(rawOK))
+ 
+  // Test that a valid status code can be created, and is correctly mapped to its status class. 
+  func testStatusCodeCreation() {
+    let myOK = HTTPStatusCode(rawValue: 200)
+    XCTAssertNotNil(myOK)
+    if let myOK = myOK {
+        XCTAssertTrue(myOK.class == .successful)
     }
-    XCTAssertTrue(HTTPStatusCode.successRange.contains(.OK))
-
-    let rawContinue = HTTPStatusCode(rawValue: 100)
-    XCTAssertNotNil(rawContinue)
-    if let rawContinue = rawContinue {
-        XCTAssertFalse(HTTPStatusCode.successRange.contains(rawContinue))
-    }
-    XCTAssertFalse(HTTPStatusCode.successRange.contains(.`continue`))
-
-    let rawMultipleChoices = HTTPStatusCode(rawValue: 300)
-    XCTAssertNotNil(rawMultipleChoices)
-    if let rawMultipleChoices = rawMultipleChoices {
-        XCTAssertFalse(HTTPStatusCode.successRange.contains(rawMultipleChoices))
-    }
-    XCTAssertFalse(HTTPStatusCode.successRange.contains(.multipleChoices))
   }
 
-  func testServerErrorRange() {
-    let rawInternalError = HTTPStatusCode(rawValue: 500)
-    XCTAssertNotNil(rawInternalError)
-    if let rawInternalError = rawInternalError {
-        XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(rawInternalError))
-    }
-    XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(.internalServerError))
+  // Test that an undefined status code cannot be created
+  func testInvalidStatusCode() {
+    let invalidStatus = HTTPStatusCode(rawValue: 418)
+    XCTAssertNil(invalidStatus)
+  }
 
-    let rawNetAuthReqd = HTTPStatusCode(rawValue: 511)
-    XCTAssertNotNil(rawNetAuthReqd)
-    if let rawNetAuthReqd = rawNetAuthReqd {
-        XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(rawNetAuthReqd))
-    }
-    XCTAssertTrue(HTTPStatusCode.serverErrorRange.contains(.networkAuthenticationRequired))
-
-    let rawBadRequest = HTTPStatusCode(rawValue: 400)
-    XCTAssertNotNil(rawBadRequest)
-    if let rawBadRequest = rawBadRequest {
-        XCTAssertFalse(HTTPStatusCode.serverErrorRange.contains(rawBadRequest))
-    }
-    XCTAssertFalse(HTTPStatusCode.serverErrorRange.contains(.badRequest))
+  // Test that a status code in each category is correctly mapped to its status class.
+  func testClassOfStatusCode() {
+    XCTAssertTrue(HTTPStatusCode.OK.class == .successful)
+    XCTAssertTrue(HTTPStatusCode.`continue`.class == .informational)
+    XCTAssertTrue(HTTPStatusCode.multipleChoices.class == .redirection)
+    XCTAssertTrue(HTTPStatusCode.badRequest.class == .clientError)
+    XCTAssertTrue(HTTPStatusCode.internalServerError.class == .serverError)
   }
 
 }
@@ -72,8 +50,9 @@ class HTTPStatusCodeTests: KituraNetTest {
 extension HTTPStatusCodeTests {
   static var allTests : [(String, (HTTPStatusCodeTests) -> () throws -> Void)] {
     return [
-             ("testSuccessRange", testSuccessRange),
-             ("testServerErrorRange", testServerErrorRange),
+             ("testStatusCodeCreation", testStatusCodeCreation),
+             ("testInvalidStatusCode", testInvalidStatusCode),
+             ("testClassOfStatusCode", testClassOfStatusCode),
     ]
   }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -55,5 +55,6 @@ XCTMain([
     testCase(ParserTests.allTests.shuffled()),
     testCase(SocketManagerTests.allTests.shuffled()),
     testCase(UpgradeTests.allTests.shuffled()),
-    testCase(RegressionTests.allTests.shuffled())
+    testCase(RegressionTests.allTests.shuffled()),
+    testCase(HTTPStatusCodeTests.allTests.shuffled())
     ].shuffled())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#240 recently introduced a `successRange` on HTTPStatusCode.  

This PR replicates the approach taken by the [swift-server working group](https://github.com/swift-server/HTTP), defining a computed enum that indicates the class (ie. range) that the status code falls within, defining `.informational`, `.successful`, `.redirection`, `.clientError` and `.serverError` status classes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have added a test for each class.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
