### PR TITLE
Correct intermittent test failure

### DIFF
--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -118,7 +118,7 @@ class ClientE2ETests: KituraNetTest {
         let secondBuffer = "80\r\nContent-Length: 6\r\n\r\nabcdefPO"
         let thirdBuffer = "ST / HTTP/1.1\r\nHost: localhost:8080\r\nContent-Length: 6\r\n\r\nabcdef"
         let expectedResponse = "Read 6 bytes"
-        let totalRequests = 2
+        let totalRequests = 3
         doPipelineTest(expecting: expectedResponse, totalRequests: totalRequests) {
             socket in
             // Disable Nagle's algorithm on this socket to flush first write


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The number of pipelined requests in `testPipeliningSpanningPackets()` was incorrectly declared as `2`, where it should have been `3`.  Rather surprisingly, the test still passed - intermittently - while very occasionally failing (as it should have all along) because there was unparsed data still in the buffer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This test is somewhat fragile, because it is attempting to test Kitura-net's ability to correctly buffer and parse pipelined requests that are received in a fragmented manner (spanning socket reads).  To do so, it artificially delays the sending of data to the wire and disables Nagle's algorithm for the socket.  My guess is that in a CI environment, this does not reliably result in multiple packets as intended.

The test is still useful because it does sometimes test this behaviour, but in some cases I suspect it is doing little more than the previous `testPipelining()` test.  At the very least, it should not fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
