### PR TITLE
Query parameters become nil on empty string

### DIFF
--- a/Sources/KituraNet/HTTPParser/URLParser.swift
+++ b/Sources/KituraNet/HTTPParser/URLParser.swift
@@ -149,7 +149,7 @@ public class URLParser : CustomStringConvertible {
             for pair in pairs {
                     
                 let pairArray = pair.components(separatedBy: "=")
-                if pairArray.count == 2 {
+                if pairArray.count == 2 && pairArray[1] != "" {
                     queryParameters[pairArray[0]] = pairArray[1]
                 }
             }

--- a/Tests/KituraNetTests/ParserTests.swift
+++ b/Tests/KituraNetTests/ParserTests.swift
@@ -49,6 +49,19 @@ class ParserTests: KituraNetTest {
         XCTAssertEqual(urlParser.queryParameters["key1"], "value1", "Incorrect query")
     }
     
+    func testEmptyStringQueryParameter() {
+        let url = "abc://username:password@example.com:123/path/data?key=value&key1=#fragid1".data(using: .utf8)!
+        let urlParser = URLParser(url: url, isConnect: false)
+        XCTAssertEqual(urlParser.schema, "abc", "Incorrect schema")
+        XCTAssertEqual(urlParser.host, "example.com", "Incorrect host")
+        XCTAssertEqual(urlParser.path, "/path/data", "Incorrect path")
+        XCTAssertEqual(urlParser.port, 123, "Incorrect port")
+        XCTAssertEqual(urlParser.fragment, "fragid1", "Incorrect fragment")
+        XCTAssertEqual(urlParser.userinfo, "username:password", "Incorrect userinfo")
+        XCTAssertEqual(urlParser.queryParameters["key"], "value", "Incorrect query")
+        XCTAssertEqual(urlParser.queryParameters["key1"], nil, "Incorrect query")
+    }
+    
     func testParserDescription() {
         let url = "abc://username:password@example.com:123/path/data?key=value#fragid1".data(using: .utf8)!
         let urlParser = URLParser(url: url, isConnect: false)


### PR DESCRIPTION
## Description
To match the behavior is Kitura in this [pull request](https://github.com/IBM-Swift/Kitura/pull/1262), This pull request changes the Query parameter parser to treat empty strings as nil. 

## Motivation and Context
This was brought in following from an [issue](https://github.com/IBM-Swift/Kitura/issues/1261) In Kitura where HTML forms would send the empty string to represent nil for forms and we would claim they are invalid because they are strings. 

Since get forms use URL query parameters and to make our handling if URLEncoded data consistent we have decided to change our parsing of URLEncoded data to treat the empty string as nil. 

This parsing is done is done in both Kitura and Kitura-net and so there are two pull requests in implement these changes.

## How Has This Been Tested?
An extra test has been added which checks this behavior and all other tests are still passing on mac.

