### PR TITLE
Issues related to ClientRequest and 3xx redirection

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -536,6 +536,15 @@ private class CurlInvoker {
                     if  infoRc == CURLE_OK {
                         if  redirectUrl != nil  {
                             curlHelperSetOptString(handle, CURLOPT_URL, redirectUrl)
+                            var status: Int = -1
+                            let codeRc = curlHelperGetInfoLong(handle, CURLINFO_RESPONSE_CODE, &status)
+                            // If the status code was 303 See Other, ensure that
+                            // the redirect is done with a GET query rather than
+                            // whatever might have just been used.
+                            if codeRc == CURLE_OK && status == 303 {
+                                var yes: Int8 = 1
+                                _ = curlHelperSetOptString(handle, CURLOPT_HTTPGET, &yes)
+                            }
                             redirected = true
                             delegate?.prepareForRedirect()
                             redirectCount+=1

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -546,7 +546,7 @@ private class CurlInvoker {
                     }
                 }
 
-            } while  rc == CURLE_OK  &&  redirected  &&  redirectCount < maxRedirects
+            } while  rc == CURLE_OK  &&  redirected  &&  redirectCount <= maxRedirects
         }
 
         return rc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I’ve discovered various glitches related to client redirection and ClientRequest.

- When doing a redirect, the same HTTP method will always be used for the new request; e.g., if a POST request returns a “Location” header, a POST request will be done to the new location. This is correct behavior when the response HTTP status code is 307 Temporary Redirect or 308 Permanent Redirect, and is correct inasmuch as the specifics of this are undefined for 301 Moved Permanently and 302 Found, but not correct for 308 Permanent Redirect, for which the second request must explicitly be a GET request.
- Due to a `<` being used where a `<=` is needed, there is an off-by-one error in the code that counts whether the client has redirected more than `maxRedirects` times, such that the effective limit is actually `maxRedirects` minus one - setting `maxRedirects` to 1 will cause *no* redirects to be followed, just as with setting it to 0.
- If a “Location” header is present, `ClientRequest.prepareForRedirect()` is called, even if the `maxRedirects` limit has been hit and we’re not really going to do a redirect. as `prepareForRedirect()` wipes out the response data buffer, there’s no way to “read” the response to examine, for example, its response body or its headers. A particular use case where this might be desirable is to see if a route handler is returning a “Location” header in the first place.

## Description
<!--- Describe your changes in detail -->

This PR adds code to detect and properly handle the 308 case, and to correct the above-mentioned bugs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I discovered these issues while trying to write a test for Kitura route handler that takes a user's POST data, creates a page with it, then redirects the user to the page's URL. My test failed because the content of the page after redirecting was an error page rather than what was expected, and it was because the client was doing a POST request to the path in the Location header when it should have been doing a GET one. Later experimentation and debugging surfaced the other issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The PR includes a new test case which checks various redirection-related behavior.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
