### PR TITLE
Support cookies

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -114,6 +114,17 @@ public class ClientRequest {
      */
     public private(set) var closeConnection = false
 
+    /**
+     The location of the cookie jar file from which cookies will be read and to
+     which cookies will be written. Set to nil to not use a cookie jar.
+
+     ### Usage Example: ###
+     ````swift
+     ClientRequest.cookieJar = "/tmp/my-cookies.txt"
+     ````
+     */
+    public private(set) var cookieJar: String?
+
     /// Handle for working with libCurl
     private var handle: UnsafeMutableRawPointer?
     
@@ -187,6 +198,9 @@ public class ClientRequest {
         
         /// If present, the client will try to use HTTP/2 protocol for the connection.
         case useHTTP2
+
+        /// Specifies location of cooke jar file. To not read or write cookies, set to nil
+        case cookieJar(String?)
         
     }
 
@@ -251,6 +265,8 @@ public class ClientRequest {
                     self.userName = userName
                 case .password(let password):
                     self.password = password
+                case .cookieJar(let file):
+                    self.cookieJar = file
             }
         }
 
@@ -297,6 +313,8 @@ public class ClientRequest {
             self.disableSSLVerification = true
         case .useHTTP2:
             self.useHTTP2 = true
+        case .cookieJar(let file):
+            self.cookieJar = file
         }
     }
 
@@ -531,7 +549,8 @@ public class ClientRequest {
         }
         setMethodAndContentLength()
         setupHeaders()
-        curlHelperSetOptString(handle!, CURLOPT_COOKIEFILE, "")
+        curlHelperSetOptString(handle!, CURLOPT_COOKIEFILE, cookieJar ?? "")
+        curlHelperSetOptString(handle!, CURLOPT_COOKIEJAR, cookieJar ?? "")
 
         // To see the messages sent by libCurl, uncomment the next line of code
         //curlHelperSetOptInt(handle, CURLOPT_VERBOSE, 1)

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -449,7 +449,7 @@ class ClientE2ETests: KituraNetTest {
             // cookies it recieves back to the response body, so check if we
             // see it there.
             self.performRequest("get", path: "/", callback: { response in
-                let responseBody = try? response?.readString()
+                let responseBody = try? response?.readString() ?? ""
                 XCTAssertEqual(responseBody, uuid1, "Could not find expected cookies")
             }, requestModifier: enableCookies)
 


### PR DESCRIPTION
Curl already has built-in support for maintaining cookies between HTTP requests, including doing things like expiring old cookies and other things that normal HTTP clients do. This change surfaces that functionality for use with Kitura-net.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `public private(set) var cookieJar: String?` property to `ClientRequest`. If this is set to a non-nil String, that string is passed to Curl to use as a location for writing and reading cookies (Curl options `CURLOPT_COOKIEFILE` and `CURLOPT_COOKIEJAR` respectively). If nil, an empty string is passed to Curl for these options, which disables this functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm writing tests for a site which has some pages which only logged-in users should be able to access. I want to test this by first using [Midnight Test](https://github.com/NocturnalSolutions/MidnightTest) to fetch the pages and make sure I get 403 Forbidden responses for them; then POST credentials to the log in form's destination and re-access the pages to see if I get 200 OK responses. I could do this by managing cookies "manually" by reading and setting HTTP headers, but if Curl already supports it, why reinvent the wheel?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR includes a new test method testing the new functionality (`testCookieJar()` in `ClientE2ETests`). 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.