### PR TITLE
Swift 5: resolve Linux crash with concurrent access to socketHandlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      # Test GCD_ASYNCH codepath on Linux
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT CUSTOM_TEST_SCRIPT=testWithGCD.sh
     - os: linux
       dist: trusty
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT CUSTOM_TEST_SCRIPT=testWithGCD.sh
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT CUSTOM_TEST_SCRIPT=testWithGCD.sh DOCKER_ENVIRONMENT=CUSTOM_TEST_SCRIPT
     - os: linux
       dist: trusty
       sudo: required

--- a/Sources/KituraNet/IncomingSocketManager.swift
+++ b/Sources/KituraNet/IncomingSocketManager.swift
@@ -270,13 +270,6 @@ public class IncomingSocketManager  {
     ///   2. Removing the reference to the IncomingHTTPSocketHandler
     ///   3. Have the IncomingHTTPSocketHandler close the socket
     ///
-    /// **Note:** In order to safely update the socketHandlers Dictionary the removal
-    /// of idle sockets is done in the thread that is accepting new incoming sockets
-    /// after a socket was accepted. Had this been done in a timer, there would be a
-    /// to have a lock around the access to the socketHandlers Dictionary. The other
-    /// idea here is that if sockets aren't coming in, it doesn't matter too much if
-    /// we leave a round some idle sockets.
-    ///
     /// - Parameter allSockets: flag indicating if the manager is shutting down, and we should cleanup all sockets, not just idle ones
     private func removeIdleSockets(removeAll: Bool = false) {
         let now = Date()

--- a/Tests/KituraNetTests/SocketManagerTests.swift
+++ b/Tests/KituraNetTests/SocketManagerTests.swift
@@ -53,7 +53,7 @@ class SocketManagerTests: KituraNetTest {
             let socket1 = try Socket.create()
             let processor1 = TestIncomingSocketProcessor()
             manager.handle(socket: socket1, processor: processor1)
-            XCTAssertEqual(manager.socketHandlers.count, 1, "There should be 1 IncomingSocketHandler, there are \(manager.socketHandlers.count)")
+            XCTAssertEqual(manager.socketHandlerCount, 1, "There should be 1 IncomingSocketHandler, there are \(manager.socketHandlerCount)")
             
             // The check for idle sockets to clean up happens when new sockets arrive.
             // However the check is done at most once a minute. To avoid waiting a minute
@@ -64,7 +64,7 @@ class SocketManagerTests: KituraNetTest {
             let socket2 = try Socket.create()
             let processor2 = TestIncomingSocketProcessor()
             manager.handle(socket: socket2, processor: processor2)
-            XCTAssertEqual(manager.socketHandlers.count, 2, "There should be 2 IncomingSocketHandler, there are \(manager.socketHandlers.count)")
+            XCTAssertEqual(manager.socketHandlerCount, 2, "There should be 2 IncomingSocketHandler, there are \(manager.socketHandlerCount)")
 
             // Enable cleanup the next time there is a "new incoming socket" (see description above)
             manager.keepAliveIdleLastTimeChecked = Date().addingTimeInterval(-120.0)
@@ -75,7 +75,7 @@ class SocketManagerTests: KituraNetTest {
             let socket3 = try Socket.create()
             let processor3 = TestIncomingSocketProcessor()
             manager.handle(socket: socket3, processor: processor3)
-            XCTAssertEqual(manager.socketHandlers.count, 3, "There should be 3 IncomingSocketHandler, there are \(manager.socketHandlers.count)")
+            XCTAssertEqual(manager.socketHandlerCount, 3, "There should be 3 IncomingSocketHandler, there are \(manager.socketHandlerCount)")
             
             // Enable cleanup the next time there is a "new incoming socket" (see description above)
             manager.keepAliveIdleLastTimeChecked = Date().addingTimeInterval(-120.0)
@@ -85,7 +85,7 @@ class SocketManagerTests: KituraNetTest {
             let socket4 = try Socket.create()
             let processor4 = TestIncomingSocketProcessor()
             manager.handle(socket: socket4, processor: processor4)
-            XCTAssertEqual(manager.socketHandlers.count, 3, "There should be 3 IncomingSocketHandler, there are \(manager.socketHandlers.count)")
+            XCTAssertEqual(manager.socketHandlerCount, 3, "There should be 3 IncomingSocketHandler, there are \(manager.socketHandlerCount)")
         }
         catch let error {
             XCTFail("Failed to create a socket. Error=\(error)")

--- a/testWithGCD.sh
+++ b/testWithGCD.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+swift test -Xswiftc -DGCD_ASYNCH


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensures that modifications to the `IncomingSocketManager.socketHandlers` dictionary are performed with exclusive access, using a DispatchQueue to access the dictionary in `handle()`, `process()` and `removeIdleSockets()`.

Also adds Travis for the GCD codepath on Linux.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With Swift 5, the Kitura test suite crashes intermittently (but frequently) while accessing the `socketHandlers` dictionary.  I believe this is due to concurrent access but I haven't managed to get a clear picture from lldb so far.  Adding locking around accesses to the dictionary avoids the problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running under stress using a simple Kitura 'hello world' benchmark results in a crash almost immediately with Swift 5.  I've confirmed that the process does not crash after applying this fix.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
