### PR TITLE
fix: Workaround to pass UInt16 value for port in ClientRequest.Options

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -162,7 +162,7 @@ public class ClientRequest {
         case hostname(String)
         
         /// Specifies the port to be used in the URL of request
-        case port(Int16)
+        case port(UInt16)
         
         /// Specifies the path to be used in the URL of request
         case path(String)
@@ -351,7 +351,7 @@ public class ClientRequest {
         }
         options.append(.path(fullPath))
         if let port = url.port {
-            options.append(.port(Int16(port)))
+            options.append(.port(UInt16(port)))
         }
         if let username = url.user {
             options.append(.username(username))

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -158,7 +158,7 @@ class KituraNetTest: XCTestCase {
 
         let schema = self.useSSL ? "https" : "http"
         var options: [ClientRequest.Options] =
-            [.method(method), .schema(schema), .hostname("localhost"), .port(Int16(self.port)), .path(path), .headers(allHeaders)]
+            [.method(method), .schema(schema), .hostname("localhost"), .port(UInt16(self.port)), .path(path), .headers(allHeaders)]
         if self.useSSL {
             options.append(.disableSSLVerification)
         }

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -158,7 +158,7 @@ class KituraNetTest: XCTestCase {
 
         let schema = self.useSSL ? "https" : "http"
         var options: [ClientRequest.Options] =
-            [.method(method), .schema(schema), .hostname("localhost"), .port(UInt16(self.port)), .path(path), .headers(allHeaders)]
+            [.method(method), .schema(schema), .hostname("localhost"), .port(Int16(self.port)), .path(path), .headers(allHeaders)]
         if self.useSSL {
             options.append(.disableSSLVerification)
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Applies the fix proposed in https://github.com/IBM-Swift/Kitura-NIO/pull/140 to Kitura-net, in order to allow port values greater than Int16.max to be used with ClientRequest.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ClientRequest.Options defines the `port` option to have a value of type `Int16`.  This should be `UInt16` as it needs to represent values in the range 1 - 65,535.

This code works until you try to connect to a server whose port is in a higher port range (32,768 - 65,535), such as would happen if [you were to start the server on an ephemeral port](https://github.com/IBM-Swift/Kitura/pull/1382).

Unfortunately, it would be a breaking change for any existing users of ClientRequest (eg. Kitura's tests: https://github.com/IBM-Swift/Kitura/blob/2.6.0/Tests/KituraTests/KituraTest.swift#L161) if we were to correct the type.  Instead, this fix uses a trick to pass the bit pattern of a UInt16 value via the Int16 parameter.  This requires that the user applies their half of the trick in cases where they want to pass a value greater than Int16.max.

This was already reported under: https://github.com/IBM-Swift/Kitura-net/issues/275

More recently, https://github.com/IBM-Swift/Kitura/pull/1382 enables the Kitura tests to use an ephemeral port, so that the tests can run in parallel.  However, the default ephemeral port range on Mac is 49,152 - 65,535, which guarantees that assignment of the port value to ClientRequest.Options.port will fail.

Kitura-CouchDB also mirrors this bug, since it sits on top of ClientRequest, and we should apply similar changes: https://github.com/IBM-Swift/Kitura-CouchDB/blob/2.1.1/Sources/CouchDB/ConnectionProperties.swift#L29

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
