### PR TITLE
Faster way to calculate utf8Length

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -492,7 +492,7 @@ public class HTTPServer: Server {
                 response.statusCode = .notFound
                 let theBody = "Path not found"
                 response.headers["Content-Type"] = ["text/plain"]
-                response.headers["Content-Length"] = [String(theBody.lengthOfBytes(using: .utf8))]
+                response.headers["Content-Length"] = [String(theBody.utf8.count)]
                 try response.write(from: theBody)
                 try response.end()
             }

--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -250,7 +250,7 @@ public class HTTPServerResponse : ServerResponse {
             return
         }
         
-        let utf8Length = text.lengthOfBytes(using: .utf8)
+        let utf8Length = text.utf8.count
         var utf8: [CChar] = Array<CChar>(repeating: 0, count: utf8Length + 10) // A little bit of padding
         guard text.getCString(&utf8, maxLength: utf8Length + 10, encoding: .utf8)  else {
             return

--- a/Tests/KituraNetTests/FastCGIRequestTests.swift
+++ b/Tests/KituraNetTests/FastCGIRequestTests.swift
@@ -261,8 +261,8 @@ class FastCGIRequestTests: KituraNetTest {
     private func addNameValuePair(to: NSMutableData, name: String, value: String) {
         var bytes: [UInt8] = [0,0,0,0]
         
-        let nameCount = name.lengthOfBytes(using: .utf8)
-        let valueCount = value.lengthOfBytes(using: .utf8)
+        let nameCount = name.utf8.count
+        let valueCount = value.utf8.count
         
         // Copy length of name into the buffer
         bytes[0] = UInt8(nameCount)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Applies the same performance fix for utf8 length calculation applied in IBM-Swift/Kitura#1369 to Kitura-net, resolves a performance regression when building with Swift 5.0 snapshots.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See IBM-Swift/Kitura#1372

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The Kitura-net tests pass.
Performance evaluation of a Kitura 'hello-world' app show significant improvement for Swift 5 (and a small improvement for Swift 4.2.1), eliminating the regression seen with Swift 5 builds:

```
               | Throughput (req/s)      | CPU (%) | Mem (kb)     | Latency (ms)                   | good
Implementation | Average    | Max        | Average | Avg peak RSS | Average  | 99%      | Max      | iters
---------------|------------|------------|---------|--------------|----------|----------|----------|-------
           421 |    63587.4 |    65449.0 |    97.2 |        26145 |      2.0 |      5.4 |    202.8 |    10
       421_fix |    64299.5 |    66892.2 |    97.5 |        26094 |      2.0 |      4.1 |    203.0 |    10
            50 |    52964.2 |    54838.8 |    99.0 |        29153 |      2.4 |      3.4 |    202.0 |    10
        50_fix |    67132.1 |    68740.2 |    97.6 |        29196 |      1.9 |      4.4 |    201.5 |    10
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
