### PR TITLE
Use String.split() instead of NSString.components()

### DIFF
--- a/Sources/KituraNet/HTTPParser/URLParser.swift
+++ b/Sources/KituraNet/HTTPParser/URLParser.swift
@@ -145,12 +145,11 @@ public class URLParser : CustomStringConvertible {
         }
             
         if let query = query {
-            let pairs = query.components(separatedBy: "&")
+            let pairs = query.split(separator: "&")
             for pair in pairs {
-                    
-                let pairArray = pair.components(separatedBy: "=")
+                let pairArray = pair.split(separator: "=")
                 if pairArray.count == 2 {
-                    queryParameters[pairArray[0]] = pairArray[1]
+                    queryParameters[String(pairArray[0])] = String(pairArray[1])
                 }
             }
         }


### PR DESCRIPTION
## Description

Remove the usage of `NSString.components()` and replace it with `String.split()`.

## Motivation and Context
In Swift 5, bridging from `String` to `NSString` involves a conversion from UTF-8 to UTF-16. So we want to avoid `NSString` as much as possible.

## How Has This Been Tested?
Ran Kitura-net test suite.