### PR TITLE
[experiment] Travis: Run Kitura tests on the current PR branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
+      env: SWIFT_SNAPSHOT=4.0.3 RUN_KITURA_TESTS=1
     - os: linux
       dist: trusty
       sudo: required
@@ -57,10 +57,10 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT RUN_KITURA_TESTS=1
 
 before_install:
-  - git clone https://github.com/IBM-Swift/Package-Builder.git
+  - git clone https://github.com/IBM-Swift/Package-Builder.git -b experiment
 
 script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Run Kitura tests on PR branches in travis CI

## Description
`Package-Builder` is being improved to support the running of Kitura tests on Kitura-net and Kitura-NIO branches. Enable Kitura testing on a few Travis runs by setting RUN_KITURA_TESTS=1 in the travis.yml. This PR is an experiment for now.

## Motivation and Context
Kitura's test suite serves as a much better regression test suite for new pull requests on Kitura-net and Kitura-NIO. It's a good idea to run Kitura tests on every pull-request on these repositories.