### PR TITLE
Run Kitura tests in travis CI

### DIFF
--- a/.kitura-test.sh
+++ b/.kitura-test.sh
@@ -1,37 +1,19 @@
+set -ex
+
 # Run Kitura-net tests
 swift test
-echo ">> Done running tests. Now preparing to run Kitura tests ..."
 
 # Clone Kitura
-echo ">> cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura"
 cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura
 
 # Build once
-echo ">> swift build"
 swift build
 
 # Edit package Kitura-net to point to the current branch
-echo ">> swift package edit Kitura-net --path ../Kitura-net"
 swift package edit Kitura-net --path ../Kitura-net
-echo ">> swift package edit returned $?."
-
-# If the `swift package edit` command failed, exit with the same failure code
-PACKAGE_EDIT_RESULT=$?
-if [[ $PACKAGE_EDIT_RESULT != 0 ]]; then
-    echo ">> Failed to edit the Kitura-net dependency."
-    exit $PACKAGE_EDIT_RESULT
-fi
 
 # Run Kitura tests
-echo ">> swift test"
 swift test
-
-# If the tests failed, exit
-TEST_EXIT_CODE=$?
-if [[ $TEST_EXIT_CODE != 0 ]]; then
-    exit $TEST_EXIT_CODE
-fi
-echo ">> Done running Kitura tests."
 
 # Move back to the original build directory. This is needed on macOS builds for the subsequent swiftlint step.
 cd ../Kitura-net

--- a/.kitura-test.sh
+++ b/.kitura-test.sh
@@ -1,0 +1,37 @@
+# Run Kitura-net tests
+swift test
+echo ">> Done running tests. Now preparing to run Kitura tests ..."
+
+# Clone Kitura
+echo ">> cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura"
+cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura
+
+# Build once
+echo ">> swift build"
+swift build
+
+# Edit package Kitura-net to point to the current branch
+echo ">> swift package edit Kitura-net --path ../Kitura-net"
+swift package edit Kitura-net --path ../Kitura-net
+echo ">> swift package edit returned $?."
+
+# If the `swift package edit` command failed, exit with the same failure code
+PACKAGE_EDIT_RESULT=$?
+if [[ $PACKAGE_EDIT_RESULT != 0 ]]; then
+    echo ">> Failed to edit the Kitura-net dependency."
+    exit $PACKAGE_EDIT_RESULT
+fi
+
+# Run Kitura tests
+echo ">> swift test"
+swift test
+
+# If the tests failed, exit
+TEST_EXIT_CODE=$?
+if [[ $TEST_EXIT_CODE != 0 ]]; then
+    exit $TEST_EXIT_CODE
+fi
+echo ">> Done running Kitura tests."
+
+# Move back to the original build directory. This is needed on macOS builds for the subsequent swiftlint step.
+cd ../Kitura-net

--- a/.kitura-test.sh
+++ b/.kitura-test.sh
@@ -1,19 +1,41 @@
-set -ex
-
 # Run Kitura-net tests
+travis_start "swift_test"
+echo ">> Executing Kitura-net tests"
 swift test
+SWIFT_TEST_STATUS=$?
+travis_end
+if [ $SWIFT_TEST_STATUS -ne 0 ]; then
+  echo ">> swift test command exited with $SWIFT_TEST_STATUS"
+  # Return a non-zero status so that Package-Builder will generate a backtrace
+  return $SWIFT_TEST_STATUS
+fi
 
 # Clone Kitura
+set -e
+echo ">> Building Kitura"
+travis_start "swift_build_kitura"
 cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura
 
 # Build once
 swift build
 
 # Edit package Kitura-net to point to the current branch
+echo ">> Editing Kitura package to use latest Kitura-net"
 swift package edit Kitura-net --path ../Kitura-net
+travis_end
+set +e
 
 # Run Kitura tests
+travis_start "swift_test_kitura"
+echo ">> Executing Kitura tests"
 swift test
+SWIFT_TEST_STATUS=$?
+travis_end
+if [ $SWIFT_TEST_STATUS -ne 0 ]; then
+  echo ">> swift test command exited with $SWIFT_TEST_STATUS"
+  # Return a non-zero status so that Package-Builder will generate a backtrace
+  return $SWIFT_TEST_STATUS
+fi
 
 # Move back to the original build directory. This is needed on macOS builds for the subsequent swiftlint step.
 cd ../Kitura-net

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
+      env: SWIFT_SNAPSHOT=4.0.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.3
+      env: SWIFT_SNAPSHOT=4.1.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
     - os: linux
       dist: trusty
       sudo: required
@@ -50,14 +50,14 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true
+      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true CUSTOM_TEST_SCRIPT=.kitura-test.sh
     - os: osx
       osx_image: xcode10.1
       sudo: required
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT CUSTOM_TEST_SCRIPT=.kitura-test.sh
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
+      env: SWIFT_SNAPSHOT=4.0.3
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
+      env: SWIFT_SNAPSHOT=4.1.3
     - os: linux
       dist: trusty
       sudo: required
@@ -31,7 +31,7 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT CUSTOM_TEST_SCRIPT=.kitura-test.sh DOCKER_ENVIRONMENT=CUSTOM_TEST_SCRIPT
       # Test GCD_ASYNCH codepath on Linux
     - os: linux
       dist: trusty
@@ -50,7 +50,7 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true CUSTOM_TEST_SCRIPT=.kitura-test.sh
+      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true
     - os: osx
       osx_image: xcode10.1
       sudo: required


### PR DESCRIPTION
Run Kitura tests in Travis CI

## Description
After running Kitura-net's test suite, Kitura can be cloned and the Kitura-net dependency updated to the PR branch, enabling the running of Kitura tests.

## Motivation and Context
Many bugs actually escape Kitura-net and Kitura-NIO's tests and are caught in Kitura's tests.

## How Has This Been Tested?
#289 shows a Kitura test failure while Kitura-net tests passed