### PR TITLE
Disable curl's Expect header

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -602,6 +602,7 @@ public class ClientRequest {
                 headersList = curl_slist_append(headersList, UnsafePointer(headerString))
             }
         }
+        headersList = curl_slist_append(headersList, UnsafePointer("Expect:".cString(using: .utf8)!))
         curlHelperSetOptList(handle!, CURLOPT_HTTPHEADER, headersList)
     }
 

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -596,13 +596,16 @@ public class ClientRequest {
         if closeConnection {
             headers["Connection"] = "close"
         }
-        
+        // Unless the user has provided an Expect header, set an empty one to disable
+        // curl's default Expect: 100-continue behaviour, since Kitura does not support it.
+        if !headers.keys.contains("Expect") {
+            headers["Expect"] = ""
+        }
         for (headerKey, headerValue) in headers {
             if let headerString = "\(headerKey): \(headerValue)".cString(using: .utf8) {
                 headersList = curl_slist_append(headersList, UnsafePointer(headerString))
             }
         }
-        headersList = curl_slist_append(headersList, UnsafePointer("Expect:".cString(using: .utf8)!))
         curlHelperSetOptList(handle!, CURLOPT_HTTPHEADER, headersList)
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This relates to #293.  If we use Kitura-net's ClientRequest to send a request to a Kitura server (using either Kitura-net or Kitura-NIO) with a payload over a certain threshold, curl will stall for a second because the server does not acknowledge the `Expect: 100-continue` header that it sends.  It still works, but it adds 1 second to the request latency.

We can avoid this by setting an empty `Expect` header, which disables this feature of curl (it sends the entire request in one shot).

This is particularly beneficial to the Kitura tests, which otherwise take a second each to complete.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
