### PR TITLE
Add support for Unix sockets

### DIFF
--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -22,7 +22,7 @@ import PackageDescription
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),
     .package(url: "https://github.com/IBM-Swift/BlueSocket.git", from: "1.0.0"),
-    .package(url: "https://github.com/adellibovi/CCurl.git", .branch("master")),
+    .package(url: "https://github.com/IBM-Swift/CCurl.git", from: "1.1.0"),
     .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0")
 ]
 

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -22,7 +22,7 @@ import PackageDescription
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),
     .package(url: "https://github.com/IBM-Swift/BlueSocket.git", from: "1.0.0"),
-    .package(url: "https://github.com/IBM-Swift/CCurl.git", from: "1.0.0"),
+    .package(url: "https://github.com/adellibovi/CCurl.git", .branch("master")),
     .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0")
 ]
 

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -22,7 +22,7 @@ import PackageDescription
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),
     .package(url: "https://github.com/IBM-Swift/BlueSocket.git", from: "1.0.0"),
-    .package(url: "https://github.com/adellibovi/CCurl.git", .branch("master")),
+    .package(url: "https://github.com/IBM-Swift/CCurl.git", from: "1.1.0"),
     .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0")
 ]
 

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -22,7 +22,7 @@ import PackageDescription
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),
     .package(url: "https://github.com/IBM-Swift/BlueSocket.git", from: "1.0.0"),
-    .package(url: "https://github.com/IBM-Swift/CCurl.git", from: "1.0.0"),
+    .package(url: "https://github.com/adellibovi/CCurl.git", .branch("master")),
     .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0")
 ]
 

--- a/Sources/CCurl/shim.h
+++ b/Sources/CCurl/shim.h
@@ -81,5 +81,12 @@ static inline CURLcode curlHelperGetInfoLong(CURL *curl, CURLINFO info, long *da
     return curl_easy_getinfo(curl, info, data);
 }
 
+static inline CURLcode curlHelperSetUnixSocketPath(CURL *curl, const char *data) {
+#ifdef CURL_VERSION_UNIX_SOCKETS
+    return curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, data);
+#else
+    return CURLE_NOT_BUILT_IN;
+#endif
+}
 
 #endif /* CurlHelpers_h */

--- a/Sources/CCurl/shim.h
+++ b/Sources/CCurl/shim.h
@@ -18,6 +18,7 @@
 #define CurlHelpers_h
 
 #import <curl/curl.h>
+#import <curl/multi.h>
 
 #define CURL_TRUE  1
 #define CURL_FALSE 0
@@ -79,6 +80,10 @@ static inline CURLcode curlHelperGetInfoCString(CURL *curl, CURLINFO info, char 
 
 static inline CURLcode curlHelperGetInfoLong(CURL *curl, CURLINFO info, long *data) {
     return curl_easy_getinfo(curl, info, data);
+}
+
+static inline CURLMcode curlHelperSetMultiOpt(CURLM *curlMulti, CURLMoption option, long data) {
+    return curl_multi_setopt(curlMulti, option, data);
 }
 
 static inline CURLcode curlHelperSetUnixSocketPath(CURL *curl, const char *data) {

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -148,6 +148,10 @@ public class ClientRequest {
 
     /// Should HTTP/2 protocol be used
     private var useHTTP2 = false
+    
+    /// The Unix socket path used for the request
+    private var socketPath: String? = nil
+
 
     /// Data that represents the "HTTP/2 " header status line prefix
     fileprivate static let Http2StatusLineVersion = "HTTP/2 ".data(using: .utf8)!
@@ -210,6 +214,9 @@ public class ClientRequest {
         /// If present, the client will try to use HTTP/2 protocol for the connection.
         case useHTTP2
         
+        /// If present, the client will connect using the Unix Socket
+        case socketPath(String)
+        
     }
 
     /**
@@ -252,7 +259,7 @@ public class ClientRequest {
         for option in options  {
             switch(option) {
 
-                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2:
+                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2, .socketPath:
                     // call set() for Options that do not construct the URL
                     set(option)
                 case .schema(var schema):
@@ -320,6 +327,8 @@ public class ClientRequest {
             self.disableSSLVerification = true
         case .useHTTP2:
             self.useHTTP2 = true
+        case .socketPath(let socketPath):
+            self.socketPath = socketPath
         }
     }
 
@@ -561,6 +570,10 @@ public class ClientRequest {
 		
         if useHTTP2 {
             curlHelperSetOptInt(handle!, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0)
+        }
+        
+        if let socketPath = socketPath?.cString(using: .utf8) {
+            curlHelperSetUnixSocketPath(handle!, UnsafePointer(socketPath))
         }
     }
 

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -149,8 +149,8 @@ public class ClientRequest {
     /// Should HTTP/2 protocol be used
     private var useHTTP2 = false
     
-    /// The Unix socket path used for the request
-    private var socketPath: String? = nil
+    /// The Unix domain socket path used for the request
+    private var unixDomainSocketPath: String? = nil
 
 
     /// Data that represents the "HTTP/2 " header status line prefix
@@ -243,11 +243,11 @@ public class ClientRequest {
     /// Initializes a `ClientRequest` instance
     ///
     /// - Parameter options: An array of `Options' describing the request.
-    /// - Parameter socketPath: Specifies a Unix socket that the client should connect to.
+    /// - Parameter unixDomainSocketPath: Specifies the path of a Unix domain socket that the client should connect to.
     /// - Parameter callback: The closure of type `Callback` to be used for the callback.
-    init(options: [Options], socketPath: String? = nil, callback: @escaping Callback) {
+    init(options: [Options], unixDomainSocketPath: String? = nil, callback: @escaping Callback) {
 
-        self.socketPath = socketPath
+        self.unixDomainSocketPath = unixDomainSocketPath
         self.callback = callback
 
         var theSchema = "http://"
@@ -569,7 +569,7 @@ public class ClientRequest {
             curlHelperSetOptInt(handle!, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0)
         }
         
-        if let socketPath = socketPath?.cString(using: .utf8) {
+        if let socketPath = unixDomainSocketPath?.cString(using: .utf8) {
             curlHelperSetUnixSocketPath(handle!, UnsafePointer(socketPath))
         }
     }

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -247,16 +247,13 @@ public class ClientRequest {
     /// - Parameter callback: The closure of type `Callback` to be used for the callback.
     init(options: [Options], socketPath: String? = nil, callback: @escaping Callback) {
 
+        self.socketPath = socketPath
         self.callback = callback
 
         var theSchema = "http://"
         var hostName = "localhost"
         var path = ""
         var port = ""
-
-        if let socketPath = socketPath {
-            self.socketPath = socketPath
-        }
 
         for option in options  {
             switch(option) {

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -213,10 +213,7 @@ public class ClientRequest {
         
         /// If present, the client will try to use HTTP/2 protocol for the connection.
         case useHTTP2
-        
-        /// If present, the client will connect using the Unix Socket
-        case socketPath(String)
-        
+
     }
 
     /**
@@ -245,9 +242,10 @@ public class ClientRequest {
 
     /// Initializes a `ClientRequest` instance
     ///
-    /// - Parameter options: An array of `Options' describing the request
+    /// - Parameter options: An array of `Options' describing the request.
+    /// - Parameter socketPath: Specifies a Unix socket that the client should connect to.
     /// - Parameter callback: The closure of type `Callback` to be used for the callback.
-    init(options: [Options], callback: @escaping Callback) {
+    init(options: [Options], socketPath: String? = nil, callback: @escaping Callback) {
 
         self.callback = callback
 
@@ -256,10 +254,14 @@ public class ClientRequest {
         var path = ""
         var port = ""
 
+        if let socketPath = socketPath {
+            self.socketPath = socketPath
+        }
+
         for option in options  {
             switch(option) {
 
-                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2, .socketPath:
+                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2:
                     // call set() for Options that do not construct the URL
                     set(option)
                 case .schema(var schema):
@@ -327,8 +329,6 @@ public class ClientRequest {
             self.disableSSLVerification = true
         case .useHTTP2:
             self.useHTTP2 = true
-        case .socketPath(let socketPath):
-            self.socketPath = socketPath
         }
     }
 

--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -115,19 +115,20 @@ public class HTTP {
     Create a new `ClientRequest` using a list of options.
     
     - Parameter options: a list of `ClientRequest.Options`.
-    - Parameter socketPath: a Unix socket path that this client should connect to (defaults to `nil`).
-    - Parameter callback: closure to run after the request.
+    - Parameter unixDomainSocketPath: the path of a Unix domain socket that this client should connect to (defaults to `nil`).
+    - Parameter callback: The closure to run after the request completes. The `ClientResponse?` parameter allows access to the response from the server.
     - Returns: a `ClientRequest` instance
     
     ### Usage Example: ###
     ````swift
-    let request = HTTP.request([ClientRequest.Options]) {response in
-        ...
+     let myOptions: [ClientRequest.Options] = [.hostname("localhost"), .port("8080")]
+    let request = HTTP.request(myOptions) { response in
+        // Process the ClientResponse
     }
     ````
     */
-    public static func request(_ options: [ClientRequest.Options], socketPath: String? = nil, callback: @escaping ClientRequest.Callback) -> ClientRequest {
-        return ClientRequest(options: options, socketPath: socketPath, callback: callback)
+    public static func request(_ options: [ClientRequest.Options], unixDomainSocketPath: String? = nil, callback: @escaping ClientRequest.Callback) -> ClientRequest {
+        return ClientRequest(options: options, unixDomainSocketPath: unixDomainSocketPath, callback: callback)
     }
     
     /**

--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -115,6 +115,7 @@ public class HTTP {
     Create a new `ClientRequest` using a list of options.
     
     - Parameter options: a list of `ClientRequest.Options`.
+    - Parameter socketPath: a Unix socket path that this client should connect to (defaults to `nil`).
     - Parameter callback: closure to run after the request.
     - Returns: a `ClientRequest` instance
     
@@ -125,8 +126,8 @@ public class HTTP {
     }
     ````
     */
-    public static func request(_ options: [ClientRequest.Options], callback: @escaping ClientRequest.Callback) -> ClientRequest {
-        return ClientRequest(options: options, callback: callback)
+    public static func request(_ options: [ClientRequest.Options], socketPath: String? = nil, callback: @escaping ClientRequest.Callback) -> ClientRequest {
+        return ClientRequest(options: options, socketPath: socketPath, callback: callback)
     }
     
     /**

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -55,8 +55,8 @@ public class HTTPServer: Server {
     /// The TCP port on which this server listens for new connections. If `nil`, this server does not listen on a TCP socket.
     public private(set) var port: Int?
 
-    /// The Unix socket path on which this server listens for new connections. If `nil`, this server does not listen on a Unix socket.
-    public private(set) var socketPath: String?
+    /// The Unix domain socket path on which this server listens for new connections. If `nil`, this server does not listen on a Unix socket.
+    public private(set) var unixDomainSocketPath: String?
 
     /// The types of listeners we currently support.
     private enum ListenerType {
@@ -166,14 +166,14 @@ public class HTTPServer: Server {
 
      ### Usage Example: ###
      ````swift
-     try server.listen(unixSocketPath: "/my/path")
+     try server.listen(unixDomainSocketPath: "/my/path")
      ````
 
-     - Parameter unixSocketPath: Unix socket path for new connections, eg. "/my/path"
+     - Parameter unixDomainSocketPath: Unix socket path for new connections, eg. "/my/path"
      */
-    public func listen(unixSocketPath: String) throws {
-        self.socketPath = unixSocketPath
-        try listen(.unix(unixSocketPath))
+    public func listen(unixDomainSocketPath: String) throws {
+        self.unixDomainSocketPath = unixDomainSocketPath
+        try listen(.unix(unixDomainSocketPath))
     }
 
     private func listen(_ listener: ListenerType) throws {
@@ -269,22 +269,22 @@ public class HTTPServer: Server {
     }
 
     /**
-     Static method to create a new HTTP server and have it listen for connections on a Unix socket.
+     Static method to create a new HTTP server and have it listen for connections on a Unix domain socket.
 
      ### Usage Example: ###
      ````swift
-     let server = HTTPServer.listen(unixSocketPath: "/my/path", delegate: self)
+     let server = HTTPServer.listen(unixDomainSocketPath: "/my/path", delegate: self)
      ````
 
-     - Parameter unixSocketPath: Path of the Unix socket that this server should listen on.
+     - Parameter unixDomainSocketPath: The path of the Unix domain socket that this server should listen on.
      - Parameter delegate: The delegate handler for HTTP connections.
 
      - Returns: A new instance of a `HTTPServer`.
      */
-    public static func listen(unixSocketPath: String, delegate: ServerDelegate?) throws -> HTTPServer {
+    public static func listen(unixDomainSocketPath: String, delegate: ServerDelegate?) throws -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
-        try server.listen(unixSocketPath: unixSocketPath)
+        try server.listen(unixDomainSocketPath: unixDomainSocketPath)
         return server
     }
 

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -57,10 +57,7 @@ public class HTTPServerRequest: ServerRequest {
     
     /// Client connection socket
     private let socket: Socket
-
-    /// Socket's signature (required by tests)
-    let socketSignature: Socket.Signature?
-
+    
     /**
      Server IP address pulled from socket.
      
@@ -242,7 +239,6 @@ public class HTTPServerRequest: ServerRequest {
     init (socket: Socket, httpParser: HTTPParser?) {
         self.socket = socket
         self.httpParser = httpParser
-        self.socketSignature = socket.signature
     }
     
     /**

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -57,7 +57,10 @@ public class HTTPServerRequest: ServerRequest {
     
     /// Client connection socket
     private let socket: Socket
-    
+
+    /// Socket's signature (required by tests)
+    let socketSignature: Socket.Signature?
+
     /**
      Server IP address pulled from socket.
      
@@ -239,6 +242,7 @@ public class HTTPServerRequest: ServerRequest {
     init (socket: Socket, httpParser: HTTPParser?) {
         self.socket = socket
         self.httpParser = httpParser
+        self.socketSignature = socket.signature
     }
     
     /**

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -34,7 +34,7 @@ class KituraNetTest: XCTestCase {
 
     var useSSL = useSSLDefault
     var port = portDefault
-    var socketPath: String? = nil
+    var unixDomainSocketPath: String? = nil
 
     static let sslConfig: SSLService.Configuration = {
         let sslConfigDir = URL(fileURLWithPath: #file).appendingPathComponent("../SSLConfig")
@@ -70,7 +70,7 @@ class KituraNetTest: XCTestCase {
     /// - Parameter allowPortReuse: Whether to allow the TCP port to be reused by other listeners
     /// - Returns: an HTTPServer instance.
     /// - Throws: an error if the server fails to listen on the specified port or path.
-    func startServer(_ delegate: ServerDelegate?, port: Int = portDefault, socketPath: String? = nil, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault) throws -> HTTPServer {
+    func startServer(_ delegate: ServerDelegate?, port: Int = portDefault, unixDomainSocketPath: String? = nil, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault) throws -> HTTPServer {
         
         let server = HTTP.createServer()
         server.delegate = delegate
@@ -78,8 +78,8 @@ class KituraNetTest: XCTestCase {
         if useSSL {
             server.sslConfig = KituraNetTest.sslConfig
         }
-        if let socketPath = socketPath {
-            try server.listen(unixSocketPath: socketPath)
+        if let unixDomainSocketPath = unixDomainSocketPath {
+            try server.listen(unixDomainSocketPath: unixDomainSocketPath)
         } else {
             try server.listen(on: port)
         }
@@ -128,14 +128,14 @@ class KituraNetTest: XCTestCase {
         }
     }
 
-    func performServerTest(_ delegate: ServerDelegate?, socketPath: String, useSSL: Bool = useSSLDefault,
+    func performServerTest(_ delegate: ServerDelegate?, unixDomainSocketPath: String, useSSL: Bool = useSSLDefault,
                            line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
 
         do {
             self.useSSL = useSSL
-            self.socketPath = socketPath
+            self.unixDomainSocketPath = unixDomainSocketPath
 
-            let server: HTTPServer = try startServer(delegate, socketPath: socketPath, useSSL: useSSL)
+            let server: HTTPServer = try startServer(delegate, unixDomainSocketPath: unixDomainSocketPath, useSSL: useSSL)
             defer {
                 server.stop()
             }
@@ -187,7 +187,7 @@ class KituraNetTest: XCTestCase {
         }
     }
 
-    func performRequest(_ method: String, path: String, socketPath: String? = nil, close: Bool=true, callback: @escaping ClientRequest.Callback,
+    func performRequest(_ method: String, path: String, unixDomainSocketPath: String? = nil, close: Bool=true, callback: @escaping ClientRequest.Callback,
                         headers: [String: String]? = nil, requestModifier: ((ClientRequest) -> Void)? = nil) {
 
         var allHeaders = [String: String]()
@@ -205,7 +205,7 @@ class KituraNetTest: XCTestCase {
             options.append(.disableSSLVerification)
         }
 
-        let req = HTTP.request(options, socketPath: socketPath, callback: callback)
+        let req = HTTP.request(options, unixDomainSocketPath: unixDomainSocketPath, callback: callback)
         if let requestModifier = requestModifier {
             requestModifier(req)
         }

--- a/Tests/KituraNetTests/UnixSocketTests.swift
+++ b/Tests/KituraNetTests/UnixSocketTests.swift
@@ -76,7 +76,7 @@ class UnixSocketTests: KituraNetTest {
             guard let request = request as? HTTPServerRequest else {
                 return XCTFail("Request was not an HTTPServerRequest")
             }
-            guard let socketSignature = request.socketSignature else {
+            guard let socketSignature = request.signature else {
                 return XCTFail("Socket signature missing")
             }
             XCTAssertEqual(socketSignature.protocolFamily, Socket.ProtocolFamily.unix, "Socket was not a Unix socket")

--- a/Tests/KituraNetTests/UnixSocketTests.swift
+++ b/Tests/KituraNetTests/UnixSocketTests.swift
@@ -63,8 +63,8 @@ class UnixSocketTests: KituraNetTest {
     /// to that socket. The TestUnixSocketServerDelegate.handle() function will verify
     /// that the incoming request's socket is a unix socket.
     func testUnixSockets() {
-        performServerTest(unixDelegate, socketPath: socketFilePath) { expectation in
-            self.performRequest("get", path: "/banana", socketPath: self.socketFilePath, callback: { response in
+        performServerTest(unixDelegate, unixDomainSocketPath: socketFilePath) { expectation in
+            self.performRequest("get", path: "/banana", unixDomainSocketPath: self.socketFilePath, callback: { response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .OK was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
             })

--- a/Tests/KituraNetTests/UnixSocketTests.swift
+++ b/Tests/KituraNetTests/UnixSocketTests.swift
@@ -1,0 +1,93 @@
+/**
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import Dispatch
+import LoggerAPI
+
+import XCTest
+
+@testable import KituraNet
+import Socket
+
+class UnixSocketTests: KituraNetTest {
+
+    static var allTests : [(String, (UnixSocketTests) -> () throws -> Void)] {
+        return [
+            ("testUnixSockets", testUnixSockets),
+        ]
+    }
+
+    override func setUp() {
+        doSetUp()
+        // Create a file for Unix socket tests
+        socketFilePath = "/tmp/KituraNetTests.testUnixSockets.\(UUID())"
+        print("Socket file path = \(socketFilePath)")
+        let fm = FileManager.default
+        if !fm.createFile(atPath: socketFilePath, contents: Data()) {
+            XCTFail("Failed to create file \(socketFilePath)")
+        }
+    }
+
+    override func tearDown() {
+        doTearDown()
+        // Clean up temporary file
+        let fileURL = URL(fileURLWithPath: socketFilePath)
+        let fm = FileManager.default
+        do {
+            try fm.removeItem(at: fileURL)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    // Socket file path for Unix socket tests
+    private var socketFilePath: String = ""
+
+    let unixDelegate = TestUnixSocketServerDelegate()
+
+    /// Test that we can start a server on a Unix socket, and then make a ClientRequest
+    /// to that socket. The TestUnixSocketServerDelegate.handle() function will verify
+    /// that the incoming request's socket is a unix socket.
+    func testUnixSockets() {
+        performServerTest(unixDelegate, socketPath: socketFilePath) { expectation in
+            self.performRequest("get", path: "/banana", socketPath: self.socketFilePath, callback: { response in
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .OK was \(String(describing: response?.statusCode))")
+                expectation.fulfill()
+            })
+        }
+    }
+
+    class TestUnixSocketServerDelegate: ServerDelegate {
+        func handle(request: ServerRequest, response: ServerResponse) {
+            guard let request = request as? HTTPServerRequest else {
+                return XCTFail("Request was not an HTTPServerRequest")
+            }
+            guard let socketSignature = request.socketSignature else {
+                return XCTFail("Socket signature missing")
+            }
+            XCTAssertEqual(socketSignature.protocolFamily, Socket.ProtocolFamily.unix, "Socket was not a Unix socket")
+            XCTAssertEqual(request.method.lowercased(), "get")
+            response.statusCode = .OK
+            do {
+                try response.end(text: "OK")
+            } catch {
+                XCTFail("Error sending response: \(error)")
+            }
+        }
+    }
+
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -43,6 +43,7 @@ extension Sequence {
 }
 
 XCTMain([
+    testCase(UnixSocketTests.allTests.shuffled()),
     testCase(ClientE2ETests.allTests.shuffled()),
     testCase(ClientRequestTests.allTests.shuffled()),
     testCase(FastCGIProtocolTests.allTests.shuffled()),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a work-in-progress for adding support for Unix domain sockets (client and server side).  This includes a non-breaking version of #213 refactored from @adellibovi's PR, the equivalent server-side changes to allow listening on a Unix socket, and a test.

There is an equivalent PR for Kitura-NIO here: https://github.com/IBM-Swift/Kitura-NIO/pull/187 - naming needs to be reconciled in a few places.

Note: the level of CCurl required to support this is not available on Ubuntu 14.04.  I recently removed 14.04 from the CI for this repo (#295), so the tests will pass, but the Unix socket **client** support will fail (at runtime) on 14.04.  The same limitation may not apply to Kitura-NIO.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
