### PR TITLE
Allow Kitura-Net to only listen on one network address

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -56,7 +56,8 @@ public class FastCGIServer: Server {
      */
     public private(set) var port: Int?
 
-    /// Has the same meaning as node in `getaddrinfo()`.
+    /// The address of the network interface to listen on. Defaults to nil, which means this server will listen on all
+    /// interfaces.
     public private(set) var address: String?
 
     /**
@@ -111,7 +112,8 @@ public class FastCGIServer: Server {
      Listens for connections on a socket
      
      - Parameter on: port number for new connections
-     - Parameter address: has the same meaning as node in `getaddrinfo()`
+     - Parameter address: The address of a network interface to listen on, for example "localhost". The default is nil,
+                 which listens for connections on all interfaces.
 
      ### Usage Example: ###
      ````swift
@@ -151,7 +153,8 @@ public class FastCGIServer: Server {
      Static method to create a new `FastCGIServer` and have it listen for conenctions
 
      - Parameter on: port number for accepting new connections
-     - Parameter address: has the same meaning as node in `getaddrinfo()`
+     - Parameter address: The address of a network interface to listen on, for example "localhost". The default is nil,
+                 which listens for connections on all interfaces.
      - Parameter delegate: the delegate handler for FastCGI/HTTP connections
 
      - Returns: a new `FastCGIServer` instance

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -56,8 +56,8 @@ public class FastCGIServer: Server {
      */
     public private(set) var port: Int?
 
-    /// Has the same meaning as in `getaddrinfo()`.
-    public private(set) var node: String?
+    /// Has the same meaning as node in `getaddrinfo()`.
+    public private(set) var address: String?
 
     /**
      A server state.
@@ -111,16 +111,16 @@ public class FastCGIServer: Server {
      Listens for connections on a socket
      
      - Parameter on: port number for new connections
-     - Parameter node: has the same meaning as in `getaddrinfo()`
+     - Parameter address: has the same meaning as node in `getaddrinfo()`
 
      ### Usage Example: ###
      ````swift
-     try server.listen(on: port, node: "localhost")
+     try server.listen(on: port, address: "localhost")
      ````
      */
-    public func listen(on port: Int, node: String? = nil) throws {
+    public func listen(on port: Int, address: String? = nil) throws {
         self.port = port
-        self.node = node
+        self.address = address
         do {
             let socket = try Socket.create()
             self.listenSocket = socket
@@ -148,53 +148,26 @@ public class FastCGIServer: Server {
     }
 
     /**
-     Listens for connections on a socket
-     - Parameter on: port number for new connections
-     */
-    @available(*, deprecated, message: "use 'listen(on:node) throws' instead")
-    public func listen(on port: Int) throws {
-        return try listen(on: port, node: nil)
-    }
-
-    /**
      Static method to create a new `FastCGIServer` and have it listen for conenctions
 
      - Parameter on: port number for accepting new connections
-     - Parameter node: has the same meaning as in `getaddrinfo()`
+     - Parameter address: has the same meaning as node in `getaddrinfo()`
      - Parameter delegate: the delegate handler for FastCGI/HTTP connections
 
      - Returns: a new `FastCGIServer` instance
 
      ### Usage Example: ###
      ````swift
-     let server = try FastCGIServer.listen(on: port, node: "localhost", delegate: delegate)
+     let server = try FastCGIServer.listen(on: port, address: "localhost", delegate: delegate)
      ````
      */
-    public static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> FastCGIServer {
+    public static func listen(on port: Int, address: String? = nil, delegate: ServerDelegate?) throws -> FastCGIServer {
         let server = FastCGI.createServer()
         server.delegate = delegate
-        try server.listen(on: port, node: node)
+        try server.listen(on: port, address: address)
         return server
     }
 
-    /**
-     Static method to create a new `FastCGIServer` and have it listen for conenctions
-     
-     - Parameter on: port number for accepting new connections
-     - Parameter delegate: the delegate handler for FastCGI/HTTP connections
-     
-     - Returns: a new `FastCGIServer` instance
-     
-     ### Usage Example: ###
-     ````swift
-     let server = try FastCGIServer.listen(on: port, delegate: delegate)
-     ````
-     */
-    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' instead")
-    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> FastCGIServer {
-        return try listen(on: port, node: nil, delegate: delegate)
-    }
-    
     /**
      Listens for connections on a socket
      

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -56,6 +56,9 @@ public class FastCGIServer: Server {
      */
     public private(set) var port: Int?
 
+    /// Has the same meaning as in `getaddrinfo()`.
+    public private(set) var node: String?
+
     /**
      A server state.
      
@@ -108,14 +111,16 @@ public class FastCGIServer: Server {
      Listens for connections on a socket
      
      - Parameter on: port number for new connections
-     
+     - Parameter node: has the same meaning as in `getaddrinfo()`
+
      ### Usage Example: ###
      ````swift
-     try server.listen(on: port)
+     try server.listen(on: port, node: "localhost")
      ````
      */
-    public func listen(on port: Int) throws {
+    public func listen(on port: Int, node: String? = nil) throws {
         self.port = port
+        self.node = node
         do {
             let socket = try Socket.create()
             self.listenSocket = socket
@@ -143,6 +148,36 @@ public class FastCGIServer: Server {
     }
 
     /**
+     Listens for connections on a socket
+     - Parameter on: port number for new connections
+     */
+    @available(*, deprecated, message: "use 'listen(on:node) throws' instead")
+    public func listen(on port: Int) throws {
+        return try listen(on: port, node: nil)
+    }
+
+    /**
+     Static method to create a new `FastCGIServer` and have it listen for conenctions
+
+     - Parameter on: port number for accepting new connections
+     - Parameter node: has the same meaning as in `getaddrinfo()`
+     - Parameter delegate: the delegate handler for FastCGI/HTTP connections
+
+     - Returns: a new `FastCGIServer` instance
+
+     ### Usage Example: ###
+     ````swift
+     let server = try FastCGIServer.listen(on: port, node: "localhost", delegate: delegate)
+     ````
+     */
+    public static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> FastCGIServer {
+        let server = FastCGI.createServer()
+        server.delegate = delegate
+        try server.listen(on: port, node: node)
+        return server
+    }
+
+    /**
      Static method to create a new `FastCGIServer` and have it listen for conenctions
      
      - Parameter on: port number for accepting new connections
@@ -155,11 +190,9 @@ public class FastCGIServer: Server {
      let server = try FastCGIServer.listen(on: port, delegate: delegate)
      ````
      */
+    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' instead")
     public static func listen(on port: Int, delegate: ServerDelegate?) throws -> FastCGIServer {
-        let server = FastCGI.createServer()
-        server.delegate = delegate
-        try server.listen(on: port)
-        return server
+        return try listen(on: port, node: nil, delegate: delegate)
     }
     
     /**

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -55,8 +55,8 @@ public class HTTPServer: Server {
     /// The TCP port on which this server listens for new connections. If `nil`, this server does not listen on a TCP socket.
     public private(set) var port: Int?
 
-    /// Has the same meaning as in `getaddrinfo()`.
-    public private(set) var node: String?
+    /// Has the same meaning as node in `getaddrinfo()`.
+    public private(set) var address: String?
 
     /// The Unix domain socket path on which this server listens for new connections. If `nil`, this server does not listen on a Unix socket.
     public private(set) var unixDomainSocketPath: String?
@@ -154,21 +154,16 @@ public class HTTPServer: Server {
      
      ### Usage Example: ###
      ````swift
-     try server.listen(on: 8080, node: "localhost")
+     try server.listen(on: 8080, address: "localhost")
      ````
      
      - Parameter port: Port number for new connections, e.g. 8080
-     - Parameter node: has the same meaning as in `getaddrinfo()`
+     - Parameter address: has the same meaning as node in `getaddrinfo()`
      */
-    public func listen(on port: Int, node: String?) throws {
+    public func listen(on port: Int, address: String? = nil) throws {
         self.port = port
-        self.node = node
-        try listen(.inet(port, node))
-    }
-
-    @available(*, deprecated, message: "use 'listen(on:node) throws' instead")
-    public func listen(on port: Int) throws {
-        return try listen(on: port, node: nil)
+        self.address = address
+        try listen(.inet(port, address))
     }
 
     /**
@@ -264,38 +259,20 @@ public class HTTPServer: Server {
      
      ### Usage Example: ###
      ````swift
-     let server = HTTPServer.listen(on: 8080, node: "localhost", delegate: self)
+     let server = HTTPServer.listen(on: 8080, address: "localhost", delegate: self)
      ````
      
      - Parameter on: Port number for accepting new connections.
-     - Parameter node: has the same meaning as in `getaddrinfo()`
+     - Parameter address: has the same meaning as node in `getaddrinfo()`
      - Parameter delegate: The delegate handler for HTTP connections.
      
      - Returns: A new instance of a `HTTPServer`.
      */
-    public static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> HTTPServer {
+    public static func listen(on port: Int, address: String? = nil, delegate: ServerDelegate?) throws -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
-        try server.listen(on: port, node: node)
+        try server.listen(on: port, address: address)
         return server
-    }
-
-    /**
-     Static method to create a new HTTP server and have it listen for connections.
-
-     ### Usage Example: ###
-     ````swift
-     let server = HTTPServer.listen(on: 8080, delegate: self)
-     ````
-
-     - Parameter on: Port number for accepting new connections.
-     - Parameter delegate: The delegate handler for HTTP connections.
-
-     - Returns: A new instance of a `HTTPServer`.
-     */
-    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' instead")
-    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> HTTPServer {
-        return try listen(on: port, node: nil, delegate: delegate)
     }
 
     /**

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -55,7 +55,8 @@ public class HTTPServer: Server {
     /// The TCP port on which this server listens for new connections. If `nil`, this server does not listen on a TCP socket.
     public private(set) var port: Int?
 
-    /// Has the same meaning as node in `getaddrinfo()`.
+    /// The address of the network interface to listen on. Defaults to nil, which means this server will listen on all
+    /// interfaces.
     public private(set) var address: String?
 
     /// The Unix domain socket path on which this server listens for new connections. If `nil`, this server does not listen on a Unix socket.
@@ -158,7 +159,8 @@ public class HTTPServer: Server {
      ````
      
      - Parameter port: Port number for new connections, e.g. 8080
-     - Parameter address: has the same meaning as node in `getaddrinfo()`
+     - Parameter address: The address of a network interface to listen on, for example "localhost". The default is nil,
+                 which listens for connections on all interfaces.
      */
     public func listen(on port: Int, address: String? = nil) throws {
         self.port = port
@@ -263,7 +265,8 @@ public class HTTPServer: Server {
      ````
      
      - Parameter on: Port number for accepting new connections.
-     - Parameter address: has the same meaning as node in `getaddrinfo()`
+     - Parameter address: The address of a network interface to listen on, for example "localhost". The default is nil,
+                 which listens for connections on all interfaces.
      - Parameter delegate: The delegate handler for HTTP connections.
      
      - Returns: A new instance of a `HTTPServer`.

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -26,7 +26,8 @@ public protocol Server {
     /// Port number for listening for new connections.
     var port: Int? { get }
 
-    /// Has the same meaning as node in `getaddrinfo()`.
+    /// The address of the network interface to listen on. Defaults to nil, which means this server will listen on all
+    /// interfaces.
     var address: String? { get }
 
     /// A server state.
@@ -35,7 +36,8 @@ public protocol Server {
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
-    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    /// - Parameter address: The address of a network interface to listen on, for example "localhost". The default is
+    ///             nil, which listens for connections on all interfaces.
     func listen(on port: Int, address: String?) throws
 
     /// Listen for connections on a socket.
@@ -46,7 +48,8 @@ public protocol Server {
     /// Static method to create a new Server and have it listen for connections.
     ///
     /// - Parameter on: port number for accepting new connections
-    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    /// - Parameter address: The address of a network interface to listen on, for example "localhost". The default is
+    ///             nil, which listens for connections on all interfaces.
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -26,13 +26,32 @@ public protocol Server {
     /// Port number for listening for new connections.
     var port: Int? { get }
 
+    /// Has the same meaning as in `getaddrinfo()`.
+    var node: String? { get }
+
     /// A server state.
     var state: ServerState { get }
 
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
+    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    func listen(on port: Int, node: String?) throws
+
+    /// Listen for connections on a socket.
+    ///
+    /// - Parameter on: port number for new connections (eg. 8080)
+    @available(*, deprecated, message: "use 'listen(on:node) throws' with instead")
     func listen(on port: Int) throws
+
+    /// Static method to create a new Server and have it listen for connections.
+    ///
+    /// - Parameter on: port number for accepting new connections
+    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    /// - Parameter delegate: the delegate handler for HTTP connections
+    ///
+    /// - Returns: a new Server instance
+    static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> ServerType
 
     /// Static method to create a new Server and have it listen for connections.
     ///
@@ -40,6 +59,7 @@ public protocol Server {
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance
+    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' with instead")
     static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType
 
     /// Listen for connections on a socket.

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -26,8 +26,8 @@ public protocol Server {
     /// Port number for listening for new connections.
     var port: Int? { get }
 
-    /// Has the same meaning as in `getaddrinfo()`.
-    var node: String? { get }
+    /// Has the same meaning as node in `getaddrinfo()`.
+    var address: String? { get }
 
     /// A server state.
     var state: ServerState { get }
@@ -35,23 +35,22 @@ public protocol Server {
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
-    /// - Parameter node: has the same meaning as in `getaddrinfo()`
-    func listen(on port: Int, node: String?) throws
+    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    func listen(on port: Int, address: String?) throws
 
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
-    @available(*, deprecated, message: "use 'listen(on:node) throws' with instead")
     func listen(on port: Int) throws
 
     /// Static method to create a new Server and have it listen for connections.
     ///
     /// - Parameter on: port number for accepting new connections
-    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance
-    static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> ServerType
+    static func listen(on port: Int, address: String?, delegate: ServerDelegate?) throws -> ServerType
 
     /// Static method to create a new Server and have it listen for connections.
     ///
@@ -59,7 +58,6 @@ public protocol Server {
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance
-    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' with instead")
     static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType
 
     /// Listen for connections on a socket.
@@ -113,4 +111,13 @@ public protocol Server {
     /// - Returns: a Server instance
     @discardableResult
     func clientConnectionFailed(callback: @escaping (Swift.Error) -> Void) -> Self
+}
+
+extension Server {
+    public func listen(on port: Int) throws {
+        try listen(on: port, address: nil)
+    }
+    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType {
+        return try Self.listen(on: port, address: nil, delegate: delegate)
+    }
 }

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -202,7 +202,7 @@ class ClientE2ETests: KituraNetTest {
 
     func testEphemeralListeningPort() {
         do {
-            let server = try HTTPServer.listen(on: 0, node: "localhost", delegate: delegate)
+            let server = try HTTPServer.listen(on: 0, address: "localhost", delegate: delegate)
             _ = HTTP.get("http://localhost:\(server.port!)") { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -202,7 +202,7 @@ class ClientE2ETests: KituraNetTest {
 
     func testEphemeralListeningPort() {
         do {
-            let server = try HTTPServer.listen(on: 0, delegate: delegate)
+            let server = try HTTPServer.listen(on: 0, node: "localhost", delegate: delegate)
             _ = HTTP.get("http://localhost:\(server.port!)") { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -81,7 +81,7 @@ class KituraNetTest: XCTestCase {
         if let unixDomainSocketPath = unixDomainSocketPath {
             try server.listen(unixDomainSocketPath: unixDomainSocketPath)
         } else {
-            try server.listen(on: port)
+            try server.listen(on: port, node: "localhost")
         }
         return server
     }
@@ -163,7 +163,7 @@ class KituraNetTest: XCTestCase {
         do {
             self.port = port
 
-            let server = try FastCGIServer.listen(on: port, delegate: delegate)
+            let server = try FastCGIServer.listen(on: port, node: "localhost", delegate: delegate)
             server.allowPortReuse = allowPortReuse
             defer {
                 server.stop()

--- a/Tests/KituraNetTests/KituraNetTest.swift
+++ b/Tests/KituraNetTests/KituraNetTest.swift
@@ -81,7 +81,7 @@ class KituraNetTest: XCTestCase {
         if let unixDomainSocketPath = unixDomainSocketPath {
             try server.listen(unixDomainSocketPath: unixDomainSocketPath)
         } else {
-            try server.listen(on: port, node: "localhost")
+            try server.listen(on: port, address: "localhost")
         }
         return server
     }
@@ -163,7 +163,7 @@ class KituraNetTest: XCTestCase {
         do {
             self.port = port
 
-            let server = try FastCGIServer.listen(on: port, node: "localhost", delegate: delegate)
+            let server = try FastCGIServer.listen(on: port, address: "localhost", delegate: delegate)
             server.allowPortReuse = allowPortReuse
             defer {
                 server.stop()

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -55,7 +55,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: self.port, node: "localhost")
+            try server.listen(on: self.port, address: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -93,7 +93,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
         
         do {
-            try server.listen(on: self.port, node: "localhost")
+            try server.listen(on: self.port, address: "localhost")
             
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -127,7 +127,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: self.port, node: "localhost")
+            try server.listen(on: self.port, address: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -155,7 +155,7 @@ class LifecycleListenerTests: KituraNetTest {
         })
 
         do {
-            try server.listen(on: -1, node: nil)
+            try server.listen(on: -1, address: nil)
         } catch {
             // Do NOT fail the test if an error is thrown.
             // In this test case an error should be thrown.

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -55,7 +55,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: self.port)
+            try server.listen(on: self.port, node: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -93,7 +93,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
         
         do {
-            try server.listen(on: self.port)
+            try server.listen(on: self.port, node: "localhost")
             
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -127,7 +127,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: self.port)
+            try server.listen(on: self.port, node: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -155,7 +155,7 @@ class LifecycleListenerTests: KituraNetTest {
         })
 
         do {
-            try server.listen(on: -1)
+            try server.listen(on: -1, node: nil)
         } catch {
             // Do NOT fail the test if an error is thrown.
             // In this test case an error should be thrown.

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -64,7 +64,7 @@ class MonitoringTests: KituraNetTest {
         }
         
         do {
-            try server.listen(on: self.port)
+            try server.listen(on: self.port, node: nil)
         
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -64,7 +64,7 @@ class MonitoringTests: KituraNetTest {
         }
         
         do {
-            try server.listen(on: self.port, node: nil)
+            try server.listen(on: self.port, address: nil)
         
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()


### PR DESCRIPTION
## Description
@billabt was nice enough to add support for this at the BlueSocket layer [here](https://github.com/IBM-Swift/BlueSocket/commit/9d77d6b2126d099f5e56cace9727068f145daaec). However, I really want to use that functionality to fix https://github.com/IBM-Swift/Kitura/issues/1450.

I also have code ready to go for https://github.com/IBM-Swift/Kitura-NIO/pull/205 and Kitura.

## Motivation and Context
This is necessary to close https://github.com/IBM-Swift/Kitura/issues/1450. Should I open another issue for Kitura-Net?

## How Has This Been Tested?
Manual testing by myself. I also modified the test harness to use the new code path.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
