### PR TITLE
[WIP] Improve debugging of Kitura applications

### DIFF
--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -134,7 +134,10 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
      */
     public func process(_ buffer: NSData) -> Bool {
         let result: Bool
-        Log.debug("Processing buffer of size \(buffer.length) for socket \(self.socket.socketfd)")
+        assert({
+            Log.debug("Processing buffer of size \(buffer.length) for socket \(self.socket.socketfd)")
+            return true
+        }())
 
         switch(state) {
         case .reset:
@@ -238,8 +241,11 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         
         let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self) + from
         let (numberParsed, upgrade) = httpParser.execute(bytes, length: length)
-        Log.debug("HTTP parser parsed \(numberParsed) out of \(length) bytes for socket \(self.socket.socketfd)")
-        Log.debug("Buffered bytes:\n\(String(data: buffer as Data, encoding: .utf8) ?? "")")
+        assert({
+            Log.debug("HTTP parser parsed \(numberParsed) out of \(length) bytes for socket \(self.socket.socketfd)")
+            Log.debug("Buffered bytes:\n\(String(data: buffer as Data, encoding: .utf8) ?? "")")
+            return true
+        }())
         
         if completeBuffer && numberParsed == length {
             // Tell parser we reached the end

--- a/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
+++ b/Sources/KituraNet/HTTP/IncomingHTTPSocketProcessor.swift
@@ -134,7 +134,8 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
      */
     public func process(_ buffer: NSData) -> Bool {
         let result: Bool
-        
+        Log.debug("Processing buffer of size \(buffer.length) for socket \(self.socket.socketfd)")
+
         switch(state) {
         case .reset:
             httpParser.reset()
@@ -237,6 +238,8 @@ public class IncomingHTTPSocketProcessor: IncomingSocketProcessor {
         
         let bytes = buffer.bytes.assumingMemoryBound(to: Int8.self) + from
         let (numberParsed, upgrade) = httpParser.execute(bytes, length: length)
+        Log.debug("HTTP parser parsed \(numberParsed) out of \(length) bytes for socket \(self.socket.socketfd)")
+        Log.debug("Buffered bytes:\n\(String(data: buffer as Data, encoding: .utf8) ?? "")")
         
         if completeBuffer && numberParsed == length {
             // Tell parser we reached the end

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -69,6 +69,11 @@ public class IncomingSocketHandler {
 
     let socket: Socket
 
+    /// Returns the socket file descriptor of the socket handled by this handler.
+    public var socketfd: Int32 {
+        return self.socket.socketfd
+    }
+
     /**
      The `IncomingSocketProcessor` instance that processes data read from the underlying socket.
      

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -111,7 +111,7 @@ public class IncomingSocketHandler {
     init(socket: Socket, using: IncomingSocketProcessor) {
         self.socket = socket
         processor = using
-        
+       Log.debug("Socket connection \(socket.socketfd) established") 
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
             socketReaderQueue = IncomingSocketHandler.socketReaderQueues[Int(socket.socketfd) % numberOfSocketReaderQueues]
             
@@ -155,6 +155,7 @@ public class IncomingSocketHandler {
             var length = 1
             while  length > 0  {
                 length = try socket.read(into: readBuffer)
+                Log.debug("Read \(length) bytes from socket \(socket.socketfd)")
             }
             if  readBuffer.length > 0  {
                 result = handleReadHelper()
@@ -333,6 +334,7 @@ public class IncomingSocketHandler {
      ````
      */
     public func write(from data: NSData) {
+        Log.debug("writing data")
         write(from: data.bytes, length: data.length)
     }
     
@@ -348,6 +350,7 @@ public class IncomingSocketHandler {
      ````
      */
     public func write(from bytes: UnsafeRawPointer, length: Int) {
+        Log.debug("writing bytes with length \(length)")
         writeInProgress = true
         defer {
             writeInProgress = false // needs to be unset before calling close() as it is part of the guard in close()

--- a/Sources/KituraNet/IncomingSocketHandler.swift
+++ b/Sources/KituraNet/IncomingSocketHandler.swift
@@ -116,7 +116,10 @@ public class IncomingSocketHandler {
     init(socket: Socket, using: IncomingSocketProcessor) {
         self.socket = socket
         processor = using
-       Log.debug("Socket connection \(socket.socketfd) established") 
+        assert({
+            Log.debug("Socket connection \(socket.socketfd) established")
+            return true
+        }())
         #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS) || GCD_ASYNCH
             socketReaderQueue = IncomingSocketHandler.socketReaderQueues[Int(socket.socketfd) % numberOfSocketReaderQueues]
             
@@ -160,7 +163,10 @@ public class IncomingSocketHandler {
             var length = 1
             while  length > 0  {
                 length = try socket.read(into: readBuffer)
-                Log.debug("Read \(length) bytes from socket \(socket.socketfd)")
+                assert({
+                    Log.debug("Read \(length) bytes from socket \(socket.socketfd)")
+                    return true
+                }())
             }
             if  readBuffer.length > 0  {
                 result = handleReadHelper()
@@ -339,7 +345,11 @@ public class IncomingSocketHandler {
      ````
      */
     public func write(from data: NSData) {
-        Log.debug("writing data")
+        assert({
+            Log.debug("Write to socket \(socket.socketfd): NSData of length \(data.length)")
+            Log.debug("Buffered bytes:\n\(String(data: data as Data, encoding: .utf8) ?? "")")
+            return true
+        }())
         write(from: data.bytes, length: data.length)
     }
     
@@ -355,7 +365,10 @@ public class IncomingSocketHandler {
      ````
      */
     public func write(from bytes: UnsafeRawPointer, length: Int) {
-        Log.debug("writing bytes with length \(length)")
+        assert({
+            Log.debug("Write to socket \(socket.socketfd): \(length) bytes")
+            return true
+        }())
         writeInProgress = true
         defer {
             writeInProgress = false // needs to be unset before calling close() as it is part of the guard in close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds extra debug-level log messages at points where data flows into / out of Kitura, to aid debugging.

Because the log entries are (necessarily) on the critical path, the extra messages are implemented as a side-effect of evaluating an `assert()` expression, such that they are only present in debug builds.  This means zero cost for release-mode builds.

**Work in progress**: The request/response body should not be logged, as it may be arbitrary size / binary data.
 - it is also helpful to debug the request/response from ClientRequest.  The `2.3.0+debugging+client` branch adds some (very rough) logging around that, but it needs refining.

We did find it valuable to be able to see the request/response payload in a recent debugging exercise, so some way to opt in to that information could be valuable.  Possibly identifying whether the content-type indicates a human readable format which could potentially be logged (with a size limit).  This may be configuration that belongs in a more general Kitura server configuration construct (could take advantage of solution being developed for https://github.com/IBM-Swift/Kitura/issues/1384)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Aids in debugging problems at the HTTP level, such as incorrect handling of headers, malformed requests, etc.

By adding the log points under an assert, we can enrich the debugging available without impacting the performance of release-mode builds.  This still requires problem recreation to be performed on a debug-mode binary, but that should be substantially easier than requiring the user to use a different branch / patch to introduce these logs.

An example of one of the Kitura-net tests running with this change:
```
Test Case 'UpgradeTests.testSuccessfullUpgrade' started at 2019-06-04 17:07:54.903
[INFO] [HTTPServer.swift:237 listen(_:)] Listening on port 8080
[VERBOSE] [HTTPServer.swift:238 listen(_:)] Options for port 8080: maxPendingConnections: 100, allowPortReuse: false
[DEBUG] [HTTPServer.swift:352 listen(listenSocket:socketManager:)] Accepted HTTP connection from: 127.0.0.1:37730
[DEBUG] [IncomingSocketHandler.swift:120 init(socket:using:)] Socket connection 16 established
[DEBUG] [IncomingSocketHandler.swift:167 handleRead()] Read 91 bytes from socket 16
[DEBUG] [IncomingSocketHandler.swift:167 handleRead()] Read 0 bytes from socket 16
[DEBUG] [IncomingHTTPSocketProcessor.swift:137 process(_:)] Processing buffer of size 91 for socket 16
[DEBUG] [IncomingHTTPSocketProcessor.swift:242 parse(_:from:completeBuffer:)] HTTP parser parsed 91 out of 91 bytes for socket 16
[DEBUG] [IncomingHTTPSocketProcessor.swift:243 parse(_:from:completeBuffer:)] Buffered bytes:
GET /test/upgrade HTTP/1.1
Host: localhost:8080
Upgrade: testing
Connection: Upgrade


[VERBOSE] [HTTPServerRequest.swift:333 parsingCompleted()] HTTP request from=127.0.0.1; proto=http;
[DEBUG] [IncomingSocketHandler.swift:349 write(from:)] Write to socket 16: NSData of length 112
[DEBUG] [IncomingSocketHandler.swift:350 write(from:)] Buffered bytes:
HTTP/1.1 101 Switching Protocols
Upgrade: testing
Date: Tue, 04 Jun 2019 16:07:54 GMT
Connection: Upgrade


[DEBUG] [IncomingSocketHandler.swift:369 write(from:length:)] Write to socket 16: 112 bytes
[DEBUG] [IncomingSocketHandler.swift:167 handleRead()] Read 5 bytes from socket 16
[DEBUG] [IncomingSocketHandler.swift:167 handleRead()] Read 0 bytes from socket 16
[DEBUG] [IncomingSocketHandler.swift:349 write(from:)] Write to socket 16: NSData of length 16
[DEBUG] [IncomingSocketHandler.swift:350 write(from:)] Buffered bytes:

[DEBUG] [IncomingSocketHandler.swift:369 write(from:length:)] Write to socket 16: 16 bytes
[DEBUG] [IncomingSocketHandler.swift:167 handleRead()] Read 0 bytes from socket 16
[DEBUG] [IncomingSocketHandler.swift:176 handleRead()] socket remoteConnectionClosed in handleRead()
Test Case 'UpgradeTests.testSuccessfullUpgrade' passed (0.001 seconds)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Absence of performance impact has been verified when running in release mode (see comment below)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
