### PR TITLE
tests: use an in-process server in testSimpleHTTPClient

### DIFF
--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -242,8 +242,8 @@ class ClientE2ETests: KituraNetTest {
                 }
             })
             expectation.fulfill()
+        })
     }
-)}
     func testPostRequests() {
         performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("post", path: "/posttest", callback: {response in

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -217,10 +217,11 @@ class ClientE2ETests: KituraNetTest {
         _ = HTTP.get("http://www.ibm.com") {response in
             XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
             XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
-            let contentType = response?.headers["Content-Type"]
-            XCTAssertNotNil(contentType, "No ContentType header in response")
-            if let contentType = contentType {
-                XCTAssertEqual(contentType, ["text/html; charset=UTF-8"], "Content-Type header wasn't `text/html; charset=UTF-8`")
+            let contentTypeValue = response?.headers["Content-Type"]
+            XCTAssertNotNil(contentTypeValue, "No ContentType header in response")
+            if let contentType = contentTypeValue?.first {
+                let contentType = contentType.split(separator: ";")
+                XCTAssertEqual(contentType[0], "text/html", "Content-Type header wasn't `text/html`")
             }
         }
     }

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -214,18 +214,36 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testSimpleHTTPClient() {
-        _ = HTTP.get("http://www.ibm.com") {response in
-            XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-            XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
-            let contentTypeValue = response?.headers["Content-Type"]
-            XCTAssertNotNil(contentTypeValue, "No ContentType header in response")
-            if let contentType = contentTypeValue?.first {
-                let contentType = contentType.split(separator: ";")
-                XCTAssertEqual(contentType[0], "text/html", "Content-Type header wasn't `text/html`")
+        class TestDelegate : ServerDelegate {
+            func handle(request: ServerRequest, response: ServerResponse) {
+                do {
+                    response.statusCode = .OK
+                    let result = "OK"
+                    response.headers["Content-Type"] = ["text/plain"]
+                    let resultData = result.data(using: .utf8)!
+                    response.headers["Content-Length"] = ["\(resultData.count)"]
+
+                    try response.write(from: resultData)
+                    try response.end()
+                }
+                catch {
+                    print("Error reading body or writing response")
+                }
             }
         }
+        performServerTest(TestDelegate(), asyncTasks: { expectation in
+            self.performRequest("get", path: "/", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
+                let contentTypeValue = response?.headers["Content-Type"]
+                XCTAssertNotNil(contentTypeValue, "No ContentType header in response")
+                if let contentType = contentTypeValue {
+                    XCTAssertEqual(contentType, ["text/plain"], "Content-Type header wasn't `text/plain`")
+                }
+            })
+            expectation.fulfill()
     }
-
+)}
     func testPostRequests() {
         performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("post", path: "/posttest", callback: {response in

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -220,7 +220,7 @@ class ClientE2ETests: KituraNetTest {
             let contentType = response?.headers["Content-Type"]
             XCTAssertNotNil(contentType, "No ContentType header in response")
             if let contentType = contentType {
-                XCTAssertEqual(contentType, ["text/html"], "Content-Type header wasn't `text/html`")
+                XCTAssertEqual(contentType, ["text/html; charset=UTF-8"], "Content-Type header wasn't `text/html; charset=UTF-8`")
             }
         }
     }


### PR DESCRIPTION
This fixes a new failure in `ClientE2ETests.testSimpleHTTPClient`.
The `contentType` of the response from "http://www.ibm.com" changed from "text/html" to "text/html; charset=UTF-8". To avoid such failures in the future, an in-process server is used instead of an external server.