### PR TITLE
Send Basic Auth credentials in an Authorization header

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -651,7 +651,6 @@ public class ClientRequest {
         for (headerKey, headerValue) in headers {
             if let headerString = "\(headerKey): \(headerValue)".cString(using: .utf8) {
                 headersList = curl_slist_append(headersList, UnsafePointer(headerString))
-                //print("hello",headersList)
             }
         }
         curlHelperSetOptList(handle!, CURLOPT_HTTPHEADER, headersList)

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -160,10 +160,10 @@ public class ClientRequest {
     fileprivate static let Http2StatusLineVersionWithMinor = "HTTP/2.0 ".data(using: .utf8)!
 
     /// The hostname of the remote server
-    var hostName: String?
+    private var hostName: String?
 
     /// The port number of the remote server
-    var port: Int?
+    private var port: Int?
 
     private var path = ""
 
@@ -251,6 +251,9 @@ public class ClientRequest {
     }
 
     private func setUrl(_ url: URL) {
+        guard let username = self.userName , let password = self.password else {
+            return
+        }
         if let host = url.host {
             self.hostName = host
         }
@@ -266,14 +269,11 @@ public class ClientRequest {
             fullPath += "?"
             fullPath += query
         }
+
         self.path = fullPath
-
-        if let username = self.userName, let password = self.password {
-            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
-        }
-
         self.url = "\(url.scheme ?? "http")://\(self.hostName ?? "unknown")\(self.port.map { ":\($0)" } ?? "")/\(fullPath)"
-        
+        self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
+        return
     }
 
     /// Initializes a `ClientRequest` instance

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -159,6 +159,14 @@ public class ClientRequest {
     /// Data that represents the "HTTP/2.0 " (with a minor) header status line prefix
     fileprivate static let Http2StatusLineVersionWithMinor = "HTTP/2.0 ".data(using: .utf8)!
 
+    /// The hostname of the remote server
+    var hostName: String?
+
+    /// The port number of the remote server
+    var port: Int?
+
+    private var path = ""
+
     /**
     Client request options enum. This allows the client to specify certain parameteres such as HTTP headers, HTTP methods, host names, and SSL credentials.
     
@@ -237,6 +245,34 @@ public class ClientRequest {
         
         self.url = url
         self.callback = callback
+        if let url = URL(string: url) {
+            setUrl(url)
+        }
+    }
+
+    private func setUrl(_ url: URL) {
+        if let host = url.host {
+            self.hostName = host
+        }
+
+        if let port = url.port {
+            self.port = port
+        }
+
+        var fullPath = url.path
+
+        // query strings and parameters need to be appended here
+        if let query = url.query {
+            fullPath += "?"
+            fullPath += query
+        }
+        self.path = fullPath
+
+        if let username = self.userName, let password = self.password {
+            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
+        }
+
+        self.url = "\(url.scheme ?? "http")://\(self.hostName ?? "unknown")\(self.port.map { ":\($0)" } ?? "")/\(fullPath)"
         
     }
 
@@ -283,16 +319,10 @@ public class ClientRequest {
             }
         }
 
-        // Adding support for Basic HTTP authentication
-        let user = self.userName ?? ""
-        let pwd = self.password ?? ""
-        var authenticationClause = ""
-        // If either the userName or password are non-empty, add the authenticationClause
-        if (!user.isEmpty || !pwd.isEmpty) {
-          authenticationClause = "\(user):\(pwd)@"
+        if let username = self.userName, let password = self.password {
+            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
         }
-
-        url = "\(theSchema)\(authenticationClause)\(hostName)\(port)\(path)"
+        url = "\(theSchema)\(hostName)\(port)\(path)"
 
     }
 
@@ -619,6 +649,11 @@ public class ClientRequest {
         curlHelperSetOptList(handle!, CURLOPT_HTTPHEADER, headersList)
     }
 
+    private func createHTTPBasicAuthHeader(username: String, password: String) -> String {
+        let authHeader = "\(username):\(password)"
+        let data = Data(authHeader.utf8)
+        return "Basic \(data.base64EncodedString())"
+    }
 }
 
 // MARK: CurlInvokerDelegate extension

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -251,15 +251,20 @@ public class ClientRequest {
     }
 
     private func removeHttpCredentialsFromUrl(_ url: URL) {
-        guard let username = self.userName, let password = self.password else {
-            return
-        }
         if let host = url.host {
             self.hostName = host
         }
 
         if let port = url.port {
             self.port = port
+        }
+
+        if let username = url.user {
+            self.userName = username
+        }
+
+        if let password = url.password {
+            self.password = password
         }
 
         var fullPath = url.path
@@ -271,8 +276,10 @@ public class ClientRequest {
         }
 
         self.path = fullPath
-        self.url = "\(url.scheme ?? "http")://\(self.hostName ?? "unknown")\(self.port.map { ":\($0)" } ?? "")/\(fullPath)"
-        self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
+        self.url = "\(url.scheme ?? "http")://\(self.hostName ?? "unknown")\(self.port.map { ":\($0)" } ?? "")\(fullPath)"
+        if let username = self.userName, let password = self.password {
+            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
+        }
         return
     }
 

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -246,12 +246,12 @@ public class ClientRequest {
         self.url = url
         self.callback = callback
         if let url = URL(string: url) {
-            setUrl(url)
+            removeHttpCredentialsFromUrl(url)
         }
     }
 
-    private func setUrl(_ url: URL) {
-        guard let username = self.userName , let password = self.password else {
+    private func removeHttpCredentialsFromUrl(_ url: URL) {
+        guard let username = self.userName, let password = self.password else {
             return
         }
         if let host = url.host {
@@ -644,6 +644,7 @@ public class ClientRequest {
         for (headerKey, headerValue) in headers {
             if let headerString = "\(headerKey): \(headerValue)".cString(using: .utf8) {
                 headersList = curl_slist_append(headersList, UnsafePointer(headerString))
+                //print("hello",headersList)
             }
         }
         curlHelperSetOptList(handle!, CURLOPT_HTTPHEADER, headersList)


### PR DESCRIPTION
 In Kitura-NIO, to work around a percent encoding issue, it is decided to send username and password in the Authorization header instead of URL as mentioned in pull request https://github.com/IBM-Swift/Kitura-NIO/pull/208 . This pull request is needed to maintain the similar behavior in Kitura-net.
**This is a breaking change.** 