### PR TITLE
CCurl available only for Linux or macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@
  **/
 
 import PackageDescription
+import Foundation
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),

--- a/Package.swift
+++ b/Package.swift
@@ -29,9 +29,12 @@ var kituraNetDependencies: [Target.Dependency] = [
     .byName(name: "CHTTPParser"),
     .byName(name: "LoggerAPI"),
     .byName(name: "Socket"),
-    .target(name: "CCurl"),
     .byName(name: "SSLService")
 ]
+
+if ProcessInfo.processInfo.environment["KITURA_IOS"] == nil {
+    kituraNetDependencies.append(.target(name: "CCurl"))
+}
 
 #if os(Linux)
 dependencies.append(contentsOf: [

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import LoggerAPI
-import CCurl
-import Socket
 
+
+#if os(Linux) || os(macOS)
+import LoggerAPI
+import Socket
+import CCurl
 import Foundation
 
 // The public API for ClientRequest erroneously defines the port as an Int16, which is
@@ -805,3 +807,4 @@ private struct OneTimeInitializations {
     }
 }
 
+#endif

--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -92,7 +92,7 @@ public class HTTP {
     public static func createServer() -> HTTPServer {
         return HTTPServer()
     }
-    
+    #if os(Linux) || os(macOS)
     /**
     Create a new `ClientRequest` using URL.
     
@@ -153,6 +153,7 @@ public class HTTP {
         req.end()
         return req
     }
+    #endif
     
     /// A set of characters that are valid in requests.
     private static let allowedCharacterSet =  NSCharacterSet(charactersIn:"\"#%/<>?@\\^`{|} ").inverted


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CCurl available only for Linux or macOS. I Use Kitura on iOS platform, so I move CCurl in other scope

## Description
<!--- Describe your changes in detail -->
Create flag KITURA_IOS
for Linux or macOS ClientRequest available(no need use CCurl on iOS )
for Linux or macOS HTTP methods available(no need use CCurl on iOS )
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use Kitura WebServer on iOS platform without magic
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I think tests no needed
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.