### PR TITLE
tests: Fix intermittent failure with GCD_ASYNCH on Linux

### DIFF
--- a/Tests/KituraNetTests/SocketManagerTests.swift
+++ b/Tests/KituraNetTests/SocketManagerTests.swift
@@ -51,6 +51,16 @@ class SocketManagerTests: KituraNetTest {
         
         do {
             let socket1 = try Socket.create()
+            let socket2 = try Socket.create()
+            let socket3 = try Socket.create()
+
+            // Sleep momentarily after creating sockets before creating any read events.
+            // For an unknown reason, with GCD_ASYNCH on Linux, a read event fires if a
+            // Dispatch reader source is set up on the socket's fd too soon, even though
+            // the socket is not connected, and this causes us to remove the socket and
+            // fail the test.
+            usleep(10000)
+
             let processor1 = TestIncomingSocketProcessor()
             manager.handle(socket: socket1, processor: processor1)
             XCTAssertEqual(manager.socketHandlerCount, 1, "There should be 1 IncomingSocketHandler, there are \(manager.socketHandlerCount)")
@@ -61,7 +71,6 @@ class SocketManagerTests: KituraNetTest {
             // last time the check for idle sockets to two minutes in the past.
             manager.keepAliveIdleLastTimeChecked = Date().addingTimeInterval(-120.0)
             
-            let socket2 = try Socket.create()
             let processor2 = TestIncomingSocketProcessor()
             manager.handle(socket: socket2, processor: processor2)
             XCTAssertEqual(manager.socketHandlerCount, 2, "There should be 2 IncomingSocketHandler, there are \(manager.socketHandlerCount)")
@@ -72,7 +81,6 @@ class SocketManagerTests: KituraNetTest {
             processor1.inProgress = false
             processor1.keepAliveUntil = Date().timeIntervalSinceReferenceDate + 240.0
             
-            let socket3 = try Socket.create()
             let processor3 = TestIncomingSocketProcessor()
             manager.handle(socket: socket3, processor: processor3)
             XCTAssertEqual(manager.socketHandlerCount, 3, "There should be 3 IncomingSocketHandler, there are \(manager.socketHandlerCount)")


### PR DESCRIPTION
Fixes this intermittent test failure when running in GCD_ASYNCH mode on Linux:
```bash
Test Suite 'SocketManagerTests' started at 2019-09-06 01:23:34.521
Test Case 'SocketManagerTests.testHandlerCleanup' started at 2019-09-06 01:23:34.521
[ERROR] [IncomingSocketHandler.swift:174 handleRead()] Read from socket (file descriptor 6) failed. Error = Error code: -9996(0x-270C), Socket is not connected.
[ERROR] [IncomingSocketHandler.swift:174 handleRead()] Read from socket (file descriptor 6) failed. Error = Error code: -9996(0x-270C), Socket is not connected.
/home/travis/build/IBM-Swift/Kitura-net/Tests/KituraNetTests/SocketManagerTests.swift:67: error: SocketManagerTests.testHandlerCleanup : XCTAssertEqual failed: ("0") is not equal to ("2") - There should be 2 IncomingSocketHandler, there are 0
[ERROR] [IncomingSocketHandler.swift:174 handleRead()] Read from socket (file descriptor 6) failed. Error = Error code: -9996(0x-270C), Socket is not connected.
/home/travis/build/IBM-Swift/Kitura-net/Tests/KituraNetTests/SocketManagerTests.swift:78: error: SocketManagerTests.testHandlerCleanup : XCTAssertEqual failed: ("0") is not equal to ("3") - There should be 3 IncomingSocketHandler, there are 0
[ERROR] [IncomingSocketHandler.swift:174 handleRead()] Read from socket (file descriptor 6) failed. Error = Error code: -9996(0x-270C), Socket is not connected.
/home/travis/build/IBM-Swift/Kitura-net/Tests/KituraNetTests/SocketManagerTests.swift:88: error: SocketManagerTests.testHandlerCleanup : XCTAssertEqual failed: ("0") is not equal to ("3") - There should be 3 IncomingSocketHandler, there are 0
Test Case 'SocketManagerTests.testHandlerCleanup' failed (0.002 seconds)
```

This only occurs with Dispatch, and only on Linux (running with `-Xswiftc -DGCD_ASYNCH`), and even then only intermittently (seems to be timing related).  

The test creates three (disconnected) `Socket`s, and then registers them with an IncomingSocketManager (simulating incoming connections).  As sockets are received, they are assigned an IncomingSocketHandler which - in the GCD codepath - sets up a Dispatch read source.

It appears that if the read source is set up for the socket quickly enough after the socket is created, it receives a read event (despite being disconnected).  This read event causes the socket handler to remove the connection because the socket is disconnected, and then the test fails.

By experimentation, I found that the test never fails (out of many trials) if there's a short delay between socket creation and registering the sources.